### PR TITLE
Added support for data type timestamp in BigQuery

### DIFF
--- a/R/tabledata.r
+++ b/R/tabledata.r
@@ -107,7 +107,7 @@ converter <- list(
   float = as.double,
   boolean = as.logical,
   string = identity,
-  timestamp = function(x) as.POSIXct(as.integer(x), origin = "1970-01-01", tz = "GMT")
+  timestamp = function(x) as.POSIXct(as.integer(x), origin = "1970-01-01", tz = "UTC")
 )
 
 extract_data <- function(rows, schema) {


### PR DESCRIPTION
As I got the error: Don't know how to convert type timestamp, timestamp was not supported.
Based on the description of BigQuery, Timestamp is "A decimal number specifying the number of seconds since the epoch." which is a time since 1970-01-01, the conversion function added in the code.
