### PR TITLE
add destination table to query_exec

### DIFF
--- a/R/jobs.r
+++ b/R/jobs.r
@@ -7,13 +7,15 @@
 #' @param dataset dataset name
 #' @param query SQL query string
 #' @param billing project to bill to, if different to \code{project}
+#' @param destination (optional) destination table for large queries
 #' @family jobs
 #' @return a job resource list, as documented at
 #'   \url{https://developers.google.com/bigquery/docs/reference/v2/jobs}
 #' @seealso API documentation for insert method:
 #'   \url{https://developers.google.com/bigquery/docs/reference/v2/jobs/insert}
 #' @export
-insert_query_job <- function(project, dataset, query, billing = project) {
+insert_query_job <- function(project, dataset, query, billing = project,
+                             destination = NULL) {
   assert_that(is.string(project), is.string(dataset), is.string(query),
     is.string(billing))
 
@@ -30,6 +32,16 @@ insert_query_job <- function(project, dataset, query, billing = project) {
       )
     )
   )
+
+  if (!is.null(destination)) {
+    body$configuration$query$allowLargeResults <- TRUE
+    body$configuration$query$destinationTable <- list(
+      projectId = project,
+      datasetId = dataset,
+      tableId = destination
+    )
+  }
+
   bq_post(url, body)
 }
 

--- a/R/query.r
+++ b/R/query.r
@@ -8,6 +8,9 @@
 #' @inheritParams insert_query_job
 #' @seealso Google documentation describing asynchronous queries:
 #'  \url{https://developers.google.com/bigquery/docs/queries#asyncqueries}
+#'  
+#'  Google documentation for handling large results:
+#'  \url{https://developers.google.com/bigquery/querying-data#largequeryresults}
 #' @export
 #' @examples
 #' \donttest{
@@ -16,11 +19,12 @@
 #' query_exec("publicdata", "samples", sql, billing = billing_project)
 #' }
 query_exec <- function(project, dataset, query, billing = project,
-                       page_size = 1e4, max_pages = 10, warn = TRUE) {
+                       page_size = 1e4, max_pages = 10, warn = TRUE,
+                       destination = NULL) {
   assert_that(is.string(project), is.string(dataset), is.string(query),
     is.string(billing))
 
-  job <- insert_query_job(project, dataset, query, billing)
+  job <- insert_query_job(project, dataset, query, billing, destination)
   job <- wait_for(job)
 
   dest <- job$configuration$query$destinationTable

--- a/man/insert_query_job.Rd
+++ b/man/insert_query_job.Rd
@@ -14,6 +14,8 @@
 
   \item{billing}{project to bill to, if different to
   \code{project}}
+
+  \item{destination}{(optional) destination table for large queries}
 }
 \value{
   a job resource list, as documented at

--- a/man/query_exec.Rd
+++ b/man/query_exec.Rd
@@ -14,6 +14,8 @@
 
   \item{billing}{project to bill to, if different to
   \code{project}}
+
+  \item{destination}{(optional) destination table for large queries}
 }
 \description{
   This is a high-level function that inserts a query job
@@ -32,5 +34,8 @@ query_exec("publicdata", "samples", sql, billing = billing_project)
 \seealso{
   Google documentation describing asynchronous queries:
   \url{https://developers.google.com/bigquery/docs/queries#asyncqueries}
+
+  Google documentation for handling large results:
+  \url{https://developers.google.com/bigquery/querying-data#largequeryresults}
 }
 


### PR DESCRIPTION
This was raised in #18, and adds an optional destination table to the query_exec signature.  (See the [BigQuery documentation](https://developers.google.com/bigquery/querying-data#largequeryresults) for more on the issue.
