### PR TITLE
Fix CSV quote encoding.

### DIFF
--- a/R/upload.r
+++ b/R/upload.r
@@ -74,7 +74,7 @@ standard_csv <- function(values) {
 
   # Encode special characters in strings
   is_char <- vapply(values, is.character, logical(1))
-  values[is_char] <- lapply(values[is_char], encodeString, na.encode = FALSE, quote = '"')
+  values[is_char] <- lapply(values[is_char], encodeString, na.encode = FALSE)
 
   # Encode dates and times
   is_time <- vapply(values, function(x) inherits(x, "POSIXct"), logical(1))
@@ -84,8 +84,8 @@ standard_csv <- function(values) {
   values[is_date] <- lapply(values[is_date], function(x) as.numeric(as.POSIXct(x)))
 
   tmp <- tempfile(fileext = ".csv")
-  write.table(values, tmp, sep = ",", quote = FALSE, qmethod = "escape",
-    row.names = FALSE, col.names = FALSE, na = "")
+  write.table(values, tmp, sep = ",", na = "", qmethod = "double",
+              row.names = FALSE, col.names = FALSE)
 
   # Don't read trailing nl
   readChar(tmp, file.info(tmp)$size - 1, useBytes = TRUE)

--- a/tests/testthat/test-upload.r
+++ b/tests/testthat/test-upload.r
@@ -1,0 +1,9 @@
+context("upload")
+
+test_that("ints and strings are correctly encoded as CSV", {
+  df <- data.frame(ints = c(1, NA, 3, 11), strs = c('a"b', '', NA, 'abc'))
+  df_csv <- bigrquery:::standard_csv(df)
+  expected_csv <- '1,"a""b"\n,""\n3,\n11,"abc"'
+
+  expect_equal(df_csv, expected_csv)
+})


### PR DESCRIPTION
BigQuery expects strings in CSV to be quoted in the "usual" manner, meaning that
quotes in string fields should be doubled, with the field itself in quotes.

This accomplishes this by tweaking arguments to `encodeString` and
`write.table`, and (unfortunately) quotes all string fields as a side-effect.
Adds one simple test of CSV encoding.

Fixes #30.
