### PR TITLE
Added support for maximumBillingTier option closes #133

### DIFF
--- a/R/jobs.r
+++ b/R/jobs.r
@@ -21,6 +21,7 @@
 #' @param default_dataset (optional) default dataset for any table references in
 #'   \code{query}, either as a string in the format used by BigQuery or as a
 #'   list with \code{project_id} and \code{dataset_id} entries
+#' @param maximum_billing_tier (optional) set to integer of billing tier required to overide project default.
 #' @param useLegacySql (optional) set to \code{FALSE} to enable BigQuery's standard SQL.
 #' @family jobs
 #' @return a job resource list, as documented at
@@ -32,6 +33,7 @@ insert_query_job <- function(query, project, destination_table = NULL,
                              default_dataset = NULL,
                              create_disposition = "CREATE_IF_NEEDED",
                              write_disposition = "WRITE_EMPTY",
+                             maximum_billing_tier = NULL,
                              useLegacySql = TRUE) {
   assert_that(is.string(project), is.string(query))
 
@@ -72,6 +74,10 @@ insert_query_job <- function(query, project, destination_table = NULL,
       projectId = default_dataset$project_id,
       datasetId = default_dataset$dataset_id
     )
+  }
+
+  if (!is.null(maximum_billing_tier)) {
+    body$configuration$query$maximumBillingTier <- maximum_billing_tier
   }
 
   bq_post(url, body)

--- a/R/query.r
+++ b/R/query.r
@@ -30,6 +30,7 @@ query_exec <- function(query, project, destination_table = NULL,
                        warn = TRUE,
                        create_disposition = "CREATE_IF_NEEDED",
                        write_disposition = "WRITE_EMPTY",
+                       maximum_billing_tier = NULL,
                        useLegacySql = TRUE) {
 
   dest <- run_query_job(query = query, project = project,
@@ -37,6 +38,7 @@ query_exec <- function(query, project, destination_table = NULL,
                         default_dataset = default_dataset,
                         create_disposition = create_disposition,
                         write_disposition = write_disposition,
+                        maximum_billing_tier = maximum_billing_tier,
                         useLegacySql = useLegacySql)
 
   list_tabledata(dest$projectId, dest$datasetId, dest$tableId,
@@ -48,6 +50,7 @@ query_exec <- function(query, project, destination_table = NULL,
 run_query_job <- function(query, project, destination_table, default_dataset,
                           create_disposition = "CREATE_IF_NEEDED",
                           write_disposition = "WRITE_EMPTY",
+                          maximum_billing_tier,
                           useLegacySql = TRUE) {
   assert_that(is.string(query), is.string(project))
 
@@ -55,6 +58,7 @@ run_query_job <- function(query, project, destination_table, default_dataset,
                           default_dataset = default_dataset,
                           create_disposition = create_disposition,
                           write_disposition = write_disposition,
+                          maximum_billing_tier = maximum_billing_tier,
                           useLegacySql = useLegacySql)
   job <- wait_for(job)
 


### PR DESCRIPTION
#133 Includes the additional option of maximum_billing_tier when executing a query. Which defaults to NULL. Is only included in the request to API if not null.

This option will be useful for some of the upcoming work we will be doing.