### PR TITLE
only list_tabledata if max_pages*page_size > 0

### DIFF
--- a/R/query.r
+++ b/R/query.r
@@ -48,15 +48,17 @@ query_exec <- function(query, project,
     ...
   )
 
-  list_tabledata(
-    dest$projectId,
-    dest$datasetId,
-    dest$tableId,
-    page_size = page_size,
-    max_pages = max_pages,
-    warn = warn,
-    quiet = quiet
-  )
+  if(page_size*max_pages>0){
+    list_tabledata(
+      dest$projectId,
+      dest$datasetId,
+      dest$tableId,
+      page_size = page_size,
+      max_pages = max_pages,
+      warn = warn,
+      quiet = quiet
+    )
+  }
 }
 
 # Submits a query job, waits for it, and returns information on the destination


### PR DESCRIPTION
In the case users want to create a table via query_exec, but don't want to view any of its contents they might set page_size = 0 or max_pages = 0.  If max_pages = 0 an error is thrown during list_tabledata(...).  With this PR, list_tabledata is only called if the max_pages*page_size > 0.