### PR TITLE
Fix copy function

### DIFF
--- a/R/tables.r
+++ b/R/tables.r
@@ -181,5 +181,5 @@ copy_table <- function(src, dest,
     )
   )
 
-  bq_post(url, body = bq_body(...))
+  bq_post(url, body = bq_body(body, ...))
 }


### PR DESCRIPTION
There was a type which removed the body parameter and copy function throws and error:

> 
> Error in match(x, table, nomatch = 0L) : 
>   argument "body" is missing, with no default