### PR TITLE
Added query priority parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 * Request error messages will now contain the "reason", which can contain 
   useful information for debugging (#209).
 
+* `insert_query_job()` added `priority` argument that allows to execute 
+  queries in the batch mode. Batch queries don't count towards your concurrent
+  rate limit, which can make it easier to start many queries at once (#212, @byapparov).
+
 # Version 0.4.1
 
 * Fix SQL translation omissions discovered by dbplyr 1.1.0

--- a/R/job-query.R
+++ b/R/job-query.R
@@ -22,8 +22,8 @@
 #'   `query`, either as a string in the format used by BigQuery or as a
 #'   list with `project_id` and `dataset_id` entries
 #' @param use_legacy_sql (optional) set to `FALSE` to enable BigQuery's standard SQL.
-#' @param priority (optional) Specifies a priority for the query.
-#'   Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.; see
+#' @param priority (optional) specifies execution priority of the query. Defaults to "INTERACTIVE",
+#'   other supported value is "BATCH".; see
 #'   \href{https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.priority}{the API documentation}
 #'   for more information
 #' @family jobs

--- a/R/job-query.R
+++ b/R/job-query.R
@@ -22,6 +22,10 @@
 #'   `query`, either as a string in the format used by BigQuery or as a
 #'   list with `project_id` and `dataset_id` entries
 #' @param use_legacy_sql (optional) set to `FALSE` to enable BigQuery's standard SQL.
+#' @param priority (optional) Specifies a priority for the query.
+#'   Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.; see
+#'   \href{https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.priority}{the API documentation}
+#'   for more information
 #' @family jobs
 #' @return a job resource list, as documented at
 #'   \url{https://developers.google.com/bigquery/docs/reference/v2/jobs}
@@ -34,6 +38,7 @@ insert_query_job <- function(query, project,
                              create_disposition = "CREATE_IF_NEEDED",
                              write_disposition = "WRITE_EMPTY",
                              use_legacy_sql = TRUE,
+                             priority = "INTERACTIVE",
                              ...) {
   assert_that(is.string(project), is.string(query))
 
@@ -42,7 +47,8 @@ insert_query_job <- function(query, project,
     configuration = list(
       query = list(
         query = query,
-        useLegacySql = use_legacy_sql
+        useLegacySql = use_legacy_sql,
+        priority = priority
       )
     )
   )

--- a/man/insert_query_job.Rd
+++ b/man/insert_query_job.Rd
@@ -36,8 +36,8 @@ for more information}
 
 \item{use_legacy_sql}{(optional) set to \code{FALSE} to enable BigQuery's standard SQL.}
 
-\item{priority}{(optional) Specifies a priority for the query.
-Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.; see
+\item{priority}{(optional) specifies execution priority of the query. Defaults to "INTERACTIVE",
+other supported value is "BATCH".; see
 \href{https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.priority}{the API documentation}
 for more information}
 

--- a/man/insert_query_job.Rd
+++ b/man/insert_query_job.Rd
@@ -6,7 +6,8 @@
 \usage{
 insert_query_job(query, project, destination_table = NULL,
   default_dataset = NULL, create_disposition = "CREATE_IF_NEEDED",
-  write_disposition = "WRITE_EMPTY", use_legacy_sql = TRUE, ...)
+  write_disposition = "WRITE_EMPTY", use_legacy_sql = TRUE,
+  priority = "INTERACTIVE", ...)
 }
 \arguments{
 \item{query}{SQL query string}
@@ -34,6 +35,11 @@ defaults to \code{"WRITE_EMPTY"}, other possible values are
 for more information}
 
 \item{use_legacy_sql}{(optional) set to \code{FALSE} to enable BigQuery's standard SQL.}
+
+\item{priority}{(optional) Specifies a priority for the query.
+Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.; see
+\href{https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.priority}{the API documentation}
+for more information}
 
 \item{...}{Additional arguments merged into the body of the
 request. \code{snake_case} will automatically be converted into


### PR DESCRIPTION
Priority parameter allows to execute query in batch mode, which does not count in the concurrent execution limit for the account. This closes #212.