### PR TITLE
Typo fix for "write_disposition" parameter

### DIFF
--- a/man/api-perform.Rd
+++ b/man/api-perform.Rd
@@ -119,7 +119,7 @@ queries (> 128 MB compressed).}
 "INTERACTIVE" and "BATCH". Batch queries do not start immediately,
 but are not rate-limited in the same way as interactive queries.}
 
-\item{write_dispoition}{Specifies the action that occurs if the
+\item{write_disposition}{Specifies the action that occurs if the
 destination table already exists. The following values are supported:
 \itemize{
 \item "WRITE_TRUNCATE": If the table already exists, BigQuery overwrites the


### PR DESCRIPTION
Current documentation lists it as "write_dispoition". Without update, this throws a vague error, the root cause not easily discernible. I lost a couple hours before noticing the the parameter was misspelled in the documentation.