### PR TITLE
 Added auto_unbox to the JSON for the body of request.

### DIFF
--- a/R/bq-request.R
+++ b/R/bq-request.R
@@ -116,7 +116,7 @@ bq_delete <- function(url, ..., query = NULL, token = get_access_cred()) {
 
 #' @importFrom httr POST add_headers config
 bq_post <- function(url, body, ..., query = NULL, token = get_access_cred()) {
-  json <- jsonlite::toJSON(body, pretty = TRUE)
+  json <- jsonlite::toJSON(body, pretty = TRUE, auto_unbox = TRUE)
   req <- POST(
     paste0(base_url, url),
     body = json,


### PR DESCRIPTION
This should prevent from this error when table is created with timePartitioning: 

>> Error: Invalid JSON payload received. Unknown name "type" at 'table.time_partitioning': Proto field is not repeating, cannot start list. [badRequest]