### PR TITLE
numeric type solution for #282

### DIFF
--- a/man/hello.Rd
+++ b/man/hello.Rd
@@ -1,0 +1,12 @@
+\name{hello}
+\alias{hello}
+\title{Hello, World!}
+\usage{
+hello()
+}
+\description{
+Prints 'Hello, world!'.
+}
+\examples{
+hello()
+}

--- a/src/BqField.cpp
+++ b/src/BqField.cpp
@@ -45,6 +45,8 @@ enum BqType {
 BqType parse_bq_type(std::string x) {
   if (x == "INTEGER") {
     return BQ_INTEGER;
+  } else if (x == "NUMERIC") {
+    return BQ_FLOAT;
   } else if (x == "FLOAT") {
     return BQ_FLOAT;
   } else if (x == "BOOLEAN") {
@@ -121,7 +123,7 @@ public:
     switch(type_) {
     case BQ_INTEGER:
       return Rcpp::IntegerVector(n);
-    case BQ_FLOAT:
+	case BQ_FLOAT:
       return Rcpp::DoubleVector(n);
     case BQ_BOOLEAN:
       return Rcpp::LogicalVector(n);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -44,13 +44,10 @@ BEGIN_RCPP
 END_RCPP
 }
 
-RcppExport SEXP null_to_na_(SEXP);
-
 static const R_CallMethodDef CallEntries[] = {
     {"_bigrquery_bq_parse", (DL_FUNC) &_bigrquery_bq_parse, 2},
     {"_bigrquery_bq_field_init", (DL_FUNC) &_bigrquery_bq_field_init, 2},
     {"_bigrquery_bq_parse_files", (DL_FUNC) &_bigrquery_bq_parse_files, 4},
-    {"null_to_na_", (DL_FUNC) &null_to_na_, 1},
     {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
Bigrquery don't know how to work with NUMERIC columns.
 
**ERROR**
Next code
`conbq <- DBI::dbConnect(bigrquery::bigquery(), dataset = bqdataset, project = bqproject ,
                        billing = bqproject, use_legacy_sql = FALSE)`
`sql =  "select cast(2 as NUMERIC) numeric_column"`
`dbGetQuery(conbq,sql)`

gives the error
`Error in bq_parse_files(schema_path, page_paths, n = page_info$n_rows,  : 
  Unknown type NUMERIC`

**SOLUTION**
In the file 'srt/BqField.cpp' line 48, adding the code 
`  } else if (x == "NUMERIC") {
    return BQ_FLOAT;`
solves the problem.