### PR TITLE
add translation for `median()` function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 * `as.character()` now translated to `SAFE_CAST(x AS STRING)` (#268).
 
+* `median()` now translates to `APPROX_QUANTILES(x, 2)[SAFE_ORDINAL(2)]` (@valentinumbach, #267).
+
 # bigrquery 1.0.0
 
 ## Improved downloads

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -180,7 +180,10 @@ sql_translate_env.BigQueryConnection <- function(x) {
 
       # Parallel min and max
       pmax = sql_prefix("GREATEST"),
-      pmin = sql_prefix("LEAST")
+      pmin = sql_prefix("LEAST"),
+
+      # Median
+      median = function(x) dbplyr::build_sql("APPROX_QUANTILES(", x, ", 2)[SAFE_ORDINAL(2)]")
     ),
     dbplyr::sql_translator(.parent = dbplyr::base_agg,
       n = function() dplyr::sql("count(*)"),


### PR DESCRIPTION
`median()` function translates to `APPROX_QUANTILES(x, 2)[SAFE_ORDINAL(2)]`. This fix was suggested by @edgararuiz (https://github.com/r-dbi/bigrquery/issues/267#issuecomment-423320332), but apparently not implemented.