### PR TITLE
Fixes installation failure on Solaris

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,6 +5,8 @@
 * r-hub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
 * win-builder: x86_64-w64-mingw32 + devel (2019-06-27 r76748)
 
+This update fixes a problem that prevented installation on Solaris.
+
 ## R CMD check results
 
 0 errors | 0 warnings | 0 notes

--- a/src/BqField.cpp
+++ b/src/BqField.cpp
@@ -20,6 +20,13 @@ char* strptime (const char *buf, const char *fmt, struct tm *timeptr);
 }
 #endif
 
+#if (defined(__sun) || defined(sun))
+extern "C" {
+  time_t timegm(struct tm *tm);
+}
+#endif
+
+
 // This is currently not used in favor of parse_int64(const char* x) .
 long int parse_int(const char* x) {
   errno = 0;


### PR DESCRIPTION
According to `` check_on_solaris(env_vars = c(`_R_CHECK_FORCE_SUGGESTS_` = "false")) ``, this fixes things on Solaris (i.e. we get a successful installation and clean `R CMD check`).

bigrquery currently fails to install on Solaris:

https://www.r-project.org/nosvn/R.check/r-patched-solaris-x86/bigrquery-00check.html