### PR TITLE
Added release of temporary files

### DIFF
--- a/R/bq-download.R
+++ b/R/bq-download.R
@@ -86,6 +86,7 @@ bq_table_download <-
   )
 
   table_data <- bq_parse_files(schema_path, page_paths, n = page_info$n_rows, quiet = bq_quiet(quiet))
+  unlink(page_paths) # No need to keep temporary files past this point
   convert_bigint(table_data, bigint)
 }
 


### PR DESCRIPTION
The library uses temporary files in a DBI::dbGetQuery that it never releases. This has caused an app to run out of '/tmp' space on my cluster and crash. I'm using this as a patch that has thus far prevented the problem.