### PR TITLE
Clean tmp files after bq_table_download

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ Where to learn more:
 
 ### Changes that a user will notice
 
-Temporary files are now deleted after table download. (@meztze, #343)
+Temporary files are now deleted after table download. (@meztez, #343)
 
 OAuth2 tokens are now cached at the user level, by default, instead of in `.httr-oauth` in the current project. The default OAuth app has also changed. This means you will need to re-authorize bigrquery (i.e. get a new token). You may want to delete any vestigial `.httr-oauth` files lying around your bigrquery projects.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ Where to learn more:
 
 ### Changes that a user will notice
 
+Temporary files are now deleted after table download. (@meztze, #343)
+
 OAuth2 tokens are now cached at the user level, by default, instead of in `.httr-oauth` in the current project. The default OAuth app has also changed. This means you will need to re-authorize bigrquery (i.e. get a new token). You may want to delete any vestigial `.httr-oauth` files lying around your bigrquery projects.
 
 The OAuth2 token key-value store now incorporates the associated Google user when indexing, which makes it easier to switch between Google identities.

--- a/R/bq-download.R
+++ b/R/bq-download.R
@@ -85,9 +85,10 @@ bq_table_download <-
     quiet = quiet
   )
 
+  on.exit(file.remove(c(schema_path, page_paths)))
+    
   table_data <- bq_parse_files(schema_path, page_paths, n = page_info$n_rows, quiet = bq_quiet(quiet))
   convert_bigint(table_data, bigint)
-  file.remove(c(schema_path, page_paths))
 }
 
 # This function is a modified version of

--- a/R/bq-download.R
+++ b/R/bq-download.R
@@ -87,6 +87,7 @@ bq_table_download <-
 
   table_data <- bq_parse_files(schema_path, page_paths, n = page_info$n_rows, quiet = bq_quiet(quiet))
   convert_bigint(table_data, bigint)
+  file.remove(page_paths)
 }
 
 # This function is a modified version of

--- a/R/bq-download.R
+++ b/R/bq-download.R
@@ -87,7 +87,7 @@ bq_table_download <-
 
   table_data <- bq_parse_files(schema_path, page_paths, n = page_info$n_rows, quiet = bq_quiet(quiet))
   convert_bigint(table_data, bigint)
-  file.remove(page_paths)
+  file.remove(c(schema_path, page_paths))
 }
 
 # This function is a modified version of


### PR DESCRIPTION
I don't see any particular reason to keep the files after they have been parsed. What do you think?

In reference to https://github.com/r-dbi/bigrquery/issues/343