### PR TITLE
Force BQ page query params to not use scientific notation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # bigrquery (development version)
 
+* `bq_table_download()` works once again with large row counts
+  (@gjuggler, #395). Google's API has stopped accepting `startIndex`
+  parameters with scientific formatting, which was happening for large
+  values (>1e5) by default.
+
 # bigrquery 1.3.1
 
 * Now requires gargle 0.5.0

--- a/R/bq-download.R
+++ b/R/bq-download.R
@@ -192,9 +192,11 @@ bq_download_page_handle <- function(x, begin = 0L, end = begin + 1e4) {
   assert_that(is.numeric(begin), length(begin) == 1)
   assert_that(is.numeric(end), length(end) == 1)
 
+  # Pre-format query params with forced non-scientific notation, since the BQ
+  # API doesn't accept numbers like 1e5. See issue #395 for details.
   query <- list(
-    startIndex = begin,
-    maxResults = end - begin
+    startIndex = format(begin, scientific = FALSE),
+    maxResults = format(end - begin, scientific = FALSE)
   )
 
   url <- paste0(base_url, bq_path(x$project, dataset = x$dataset, table = x$table, data = ""))

--- a/tests/testthat/test-bq-download.R
+++ b/tests/testthat/test-bq-download.R
@@ -31,16 +31,14 @@ test_that("can retrieve zero rows", {
 test_that("can specify large integers in page params", {
   skip_if_no_auth()
 
-  old_opts <- options()
   # Use scipen to nudge R to prefer scientific formatting for very small numbers
   # to allow this test to exercise issue #395 with small datasets.
-  options(scipen=-4)
+  old <- options(scipen=-4)
+  on.exit(options(old))
 
   tb <- as_bq_table("bigquery-public-data.moon_phases.moon_phases")
   df <- bq_table_download(tb, max_results = 100, page_size = 20)
   expect_equal(nrow(df), 100)
-
-  options(old_opts)
 })
 
 # bq_table_info -----------------------------------------------------------

--- a/tests/testthat/test-bq-download.R
+++ b/tests/testthat/test-bq-download.R
@@ -28,6 +28,20 @@ test_that("can retrieve zero rows", {
   expect_named(df, c("phase", "phase_emoji", "peak_datetime"))
 })
 
+test_that("can specify large integers in page params", {
+  skip_if_no_auth()
+
+  old_opts <- options()
+  # Use scipen to nudge R to prefer scientific formatting for very small numbers
+  # to allow this test to exercise issue #395 with small datasets.
+  options(scipen=-4)
+
+  tb <- as_bq_table("bigquery-public-data.moon_phases.moon_phases")
+  df <- bq_table_download(tb, max_results = 100, page_size = 20)
+  expect_equal(nrow(df), 100)
+
+  options(old_opts)
+})
 
 # bq_table_info -----------------------------------------------------------
 


### PR DESCRIPTION
Fixes #395.

I work on the All of Us Researcher Workbench project (https://github.com/all-of-us/workbench) where we guide users to fetch data from BigQuery via the bigrquery package. The issue above has been affecting our users, so we wanted to take a swing at a fix.

**Rationale**
This is a fix with more limited scope than the `httpr` alternative (https://github.com/r-lib/httr/pull/670). We simply force the page params 

**Testing**

- devtools::check() runs successfully.
- I confirmed that the added regression test fails if the code change is commented out.
- Open to suggestions for an alternative test strategy. This approach (using opts to force aggressive scientific formatting) is a bit more clever than I'd like, but it prevents us from needing to load ~100k rows to trigger this scenario.

**Notes**
An alternative to the approach in this PR would have been to use `as.integer(x)` instead of `format(x, scientific=FALSE)`. But that alternative relies on the implicit difference in R's formatting of integers vs. doubles, so I opted for the more explicit fix. I'd be curious to hear from reviewers if `as.integer` would be more robust or idiomatic.