### PR TITLE
Don't init .auth object until .onLoad

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bigrquery
 Title: An Interface to Google's 'BigQuery' 'API'
-Version: 1.3.2.9000
+Version: 1.3.2.9001
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre"),
       comment = c(ORCID = "0000-0003-4757-117X")),

--- a/R/bq-auth.R
+++ b/R/bq-auth.R
@@ -1,9 +1,8 @@
 ## This file is the interface between bigrquery and the
 ## auth functionality in gargle.
-.auth <- gargle::init_AuthState(
-  package     = "bigrquery",
-  auth_active = TRUE
-)
+
+# Initialization happens in .onLoad
+.auth <- NULL
 
 ## The roxygen comments for these functions are mostly generated from data
 ## in this list and template text maintained in gargle.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,10 @@
 .onLoad <- function(libname, pkgname) {
 
+  .auth <<- gargle::init_AuthState(
+    package     = "bigrquery",
+    auth_active = TRUE
+  )
+
   # S3 methods --------------------------------------------------------------
   register_s3_method("dplyr", "collect", "tbl_BigQueryConnection")
   register_s3_method("dplyr", "db_analyze", "BigQueryConnection")


### PR DESCRIPTION
Creating the .auth object directly at the top-level means the code
from gargle is snapshotted at build time.

This is needed for r-lib/gargle#157, but is a good change even without that PR.
