### PR TITLE
Add `billing` slot to `BigQueryResult`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bigrquery (development version)
 
+* Add `billing` slot to `BigQueryResult`.
+
 # bigrquery 1.3.2
 
 * BigQuery `BYTES` and `GEOGRAPHY` column types are now supported via

--- a/R/dbi-result.R
+++ b/R/dbi-result.R
@@ -43,7 +43,8 @@ BigQueryResult <- function(conn, sql, ...) {
     page_size = conn@page_size,
     quiet = conn@quiet,
     cursor = cursor(nrow),
-    bigint = conn@bigint
+    bigint = conn@bigint,
+    billing = conn@billing
   )
   res
 }
@@ -61,7 +62,8 @@ setClass(
     page_size = "numeric",
     quiet = "logical",
     cursor = "list",
-    bigint = "character"
+    bigint = "character",
+    billing = "character"
   )
 )
 


### PR DESCRIPTION
To facilitate integration of dbFetch with bigrquerystorage package.

BigQueryReadClient requires a billing project to iniate a ReadSession.