### PR TITLE
collect now passes con bigint parameter to bq_table_download

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Add `billing` slot to `BigQueryResult`.
 
-* When using dplyr syntax with BigQuery table, `collect()` now utilizes `bigint` parameter in `DBI::dbConnect()` object. Set `bigint =  integer64` in connection object to avoid int64 coercision to integer and resulting overflow issues. (@zoews, #439)
+* When using dplyr syntax with BigQuery table, `collect()` now utilizes `bigint` parameter in `DBI::dbConnect()` object. Set `bigint =  integer64` in connection object to avoid int64 coercision to integer and resulting overflow issues (@zoews, #439).
 
 # bigrquery 1.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Add `billing` slot to `BigQueryResult`.
 
-* When using dplyr syntax with BigQuery table, `collect()` now utilizes `bigint` parameter in `DBI::dbConnect()` object. Set `bigint =  integer64` in connection object to avoid int64 coercision to integer and resulting overflow issues.
+* When using dplyr syntax with BigQuery table, `collect()` now utilizes `bigint` parameter in `DBI::dbConnect()` object. Set `bigint =  integer64` in connection object to avoid int64 coercision to integer and resulting overflow issues. (@zoews, #439)
 
 # bigrquery 1.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Add `billing` slot to `BigQueryResult`.
 
+* When using dplyr syntax with BigQuery table, `collect()` now utilizes `bigint` parameter in `DBI::dbConnect()` object. Set `bigint =  integer64` in connection object to avoid int64 coercision to integer and resulting overflow issues.
+
 # bigrquery 1.3.2
 
 * BigQuery `BYTES` and `GEOGRAPHY` column types are now supported via

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -124,7 +124,7 @@ collect.tbl_BigQueryConnection <- function(x, ...,
   }
 
   quiet <- if (n < 100) TRUE else x$src$con@quiet
-  bigint <- if (!is.null(x$src$con@bigint)) x$src$con@bigint else "integer"
+  bigint <- x$src$con@bigint %||% "integer"
   out <- bq_table_download(tb,
     max_results = n,
     page_size = page_size,

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -124,11 +124,13 @@ collect.tbl_BigQueryConnection <- function(x, ...,
   }
 
   quiet <- if (n < 100) TRUE else x$src$con@quiet
+  bigint <- if (!is.null(x$src$con@bigint)) x$src$con@bigint else "integer"
   out <- bq_table_download(tb,
     max_results = n,
     page_size = page_size,
     quiet = quiet,
-    max_connections = max_connections
+    max_connections = max_connections,
+    bigint = bigint
   )
   dplyr::grouped_df(out, intersect(dbplyr::op_grps(x), names(out)))
 }


### PR DESCRIPTION
Fixes #439 - dplyr snytax with `collect()` now returns bit64::integer64 values as expected when reading BigQuery table with int64 column:

```{r}
...

tbl(con, long_table_name ) %>%
  select(int64_identifier) %>%
  collect() %>%
  glimpse()
#> Rows: 32
#> Columns: 1
#> $ int64_identifier <int64> 9223372036854775800, 9223372036854775800, 922337203…
```
PR passes `devtools::check()`