### PR TITLE
rewrite news item for #440 to reference #437

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Add `billing` slot to `BigQueryResult`.
 
-* Improve int64 support with dplyr syntax. Fix issue where collect() and tbl() ignored `bigint` parameter in `DBI::dbConnect()` object. Set `bigint` in connection object to `"integer64"` or `"character"` to avoid integer coercion and overflow issues (@zoews, #439, #437).
+* Improve int64 support when reading BigQuery tables with dplyr syntax. `collect()` now utilizes `bigint` parameter in `DBI::dbConnect()` object. Set `bigint` in connection object to `"integer64"` or `"character"` to avoid integer coercion and overflow issues (@zoews, #439, #437).
 
 # bigrquery 1.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Add `billing` slot to `BigQueryResult`.
 
-* When using dplyr syntax with BigQuery table, `collect()` now utilizes `bigint` parameter in `DBI::dbConnect()` object. Set `bigint =  integer64` in connection object to avoid int64 coercision to integer and resulting overflow issues (@zoews, #439).
+* Improve int64 support with dplyr syntax. Fix issue where collect() and tbl() ignored `bigint` parameter in `dbi::dbConnect()` object. Set `bigint` in connection object to `"integer64"` or `"character"` to avoid integer coercion and overflow issues (@zoews, #439, #437).
 
 # bigrquery 1.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Add `billing` slot to `BigQueryResult`.
 
-* Improve int64 support with dplyr syntax. Fix issue where collect() and tbl() ignored `bigint` parameter in `dbi::dbConnect()` object. Set `bigint` in connection object to `"integer64"` or `"character"` to avoid integer coercion and overflow issues (@zoews, #439, #437).
+* Improve int64 support with dplyr syntax. Fix issue where collect() and tbl() ignored `bigint` parameter in `DBI::dbConnect()` object. Set `bigint` in connection object to `"integer64"` or `"character"` to avoid integer coercion and overflow issues (@zoews, #439, #437).
 
 # bigrquery 1.3.2
 


### PR DESCRIPTION
After submission, caught that #440 also solves #437 (when `tbl()` is evaluated without explicitly calling `collect()`) 

I wanted to rewrite my news item to slightly clarify my language and also reference that issue. Thanks!