### PR TITLE
Fixes `bq_table_download` issue of returning empty rows with large datasets

### DIFF
--- a/R/bq-download.R
+++ b/R/bq-download.R
@@ -43,6 +43,11 @@
 #'   The default is `"integer"` which returns R's `integer` type but results in `NA` for
 #'   values above/below +/- 2147483647. `"integer64"` returns a [bit64::integer64],
 #'   which allows the full range of 64 bit integers.
+#' @param allow_fragments If FALSE, does not allow for mismatches between the number
+#'   of observations and the number of requested rows that may occur with large
+#'   records. Make `page_size` smaller if you are seeing a `num_observations not equal to page_info$n_rows`
+#'   error. If TRUE, allows mismatches, but the number of rows retrieved might be
+#'   fewer than requested.
 #' @section Google BigQuery API documentation:
 #' * [list](https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/list)
 #' @export

--- a/man/bq_auth.Rd
+++ b/man/bq_auth.Rd
@@ -24,7 +24,7 @@ always determined from the token itself, never from this argument. Use \code{NA}
 or \code{FALSE} to match nothing and force the OAuth dance in the browser. Use
 \code{TRUE} to allow email auto-discovery, if exactly one matching token is
 found in the cache. Defaults to the option named "gargle_oauth_email",
-retrieved by \code{\link[gargle:gargle_options]{gargle::gargle_oauth_email()}}.}
+retrieved by \code{\link[gargle:gargle_options]{gargle_oauth_email()}}.}
 
 \item{path}{JSON identifying the service account, in one of the forms
 supported for the \code{txt} argument of \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}} (typically, a
@@ -34,11 +34,11 @@ file path or JSON string).}
 Pick from those listed at \url{https://developers.google.com/identity/protocols/oauth2/scopes}.}
 
 \item{cache}{Specifies the OAuth token cache. Defaults to the option named
-"gargle_oauth_cache", retrieved via \code{\link[gargle:gargle_options]{gargle::gargle_oauth_cache()}}.}
+"gargle_oauth_cache", retrieved via \code{\link[gargle:gargle_options]{gargle_oauth_cache()}}.}
 
 \item{use_oob}{Whether to prefer "out of band" authentication. Defaults to
 the option named "gargle_oob_default", retrieved via
-\code{\link[gargle:gargle_options]{gargle::gargle_oob_default()}}.}
+\code{\link[gargle:gargle_options]{gargle_oob_default()}}.}
 
 \item{token}{A token with class \link[httr:Token-class]{Token2.0} or an object of
 httr's class \code{request}, i.e. a token that has been prepared with

--- a/man/bq_table_download.Rd
+++ b/man/bq_table_download.Rd
@@ -11,7 +11,8 @@ bq_table_download(
   start_index = 0L,
   max_connections = 6L,
   quiet = NA,
-  bigint = c("integer", "integer64", "numeric", "character")
+  bigint = c("integer", "integer64", "numeric", "character"),
+  allow_fragments = FALSE
 )
 }
 \arguments{
@@ -36,6 +37,12 @@ if \code{NA} displays progress bar only for long-running jobs.}
 The default is \code{"integer"} which returns R's \code{integer} type but results in \code{NA} for
 values above/below +/- 2147483647. \code{"integer64"} returns a \link[bit64:bit64-package]{bit64::integer64},
 which allows the full range of 64 bit integers.}
+
+\item{allow_fragments}{If FALSE, does not allow for mismatches between the number
+of observations and the number of requested rows that may occur with large
+records. Make \code{page_size} smaller if you are seeing a \verb{num_observations not equal to page_info$n_rows}
+error. If TRUE, allows mismatches, but the number of rows retrieved might be
+fewer than requested.}
 }
 \value{
 Because data retrieval may generalise list-cols and the data frame


### PR DESCRIPTION
**Issue:** Previously, `bq_table_download` would return empty rows in the returned data table when the temporary json files containing the data from BigQuery exceeded BigQuery's size limit (which seems to occur if a row contains an usually large amount of data like large amounts of text, large number arrays, or just a lot of fields). You could get around the problem by decreasing the page_size parameter, but since there was no indiction that this was occurring, debugging the issue took time and effort. See issues #311 and #412 for more details.

**Solution:** I have added a parameter to `bq_table_download` called `allow_fragments`. Additionally, I have added code that counts the number of total rows in the json files (num_observations) and compares this to the number of rows in the metadata of the BigQuery table (page_info$nrows).

If `allow_fragments = FALSE`, `bq_table_download` will throw an error if page_info$nrows != num_observations:

``` r
library(bigrquery)

billing <- "---"
sql <- "SELECT * FROM `bigquery-public-data.baseball.games_wide` LIMIT 20000"
results <- bq_project_query(billing, sql)
baseball <- bq_table_download(results, page_size = 10000, allow_fragments = FALSE)
#> Error: num_observations not equal to page_info$n_rows
baseball
#> Error in eval(expr, envir, enclos): object 'baseball' not found
```

<sup>Created on 2021-04-19 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>


If `allow_fragments = TRUE`, `bq_table_download` will run, but the number of rows equals num_observations, not page_info$nrows:

``` r
library(bigrquery)

billing <- "---"
sql <- "SELECT * FROM `bigquery-public-data.baseball.games_wide` LIMIT 20000"
results <- bq_project_query(billing, sql)
baseball <- bq_table_download(results, page_size = 10000, allow_fragments = TRUE)
baseball
#> # A tibble: 8,361 x 145
#>    gameId   seasonId  seasonType  year startTime           gameStatus attendance
#>    <chr>    <chr>     <chr>      <int> <dttm>              <chr>           <int>
#>  1 dc42dfe… 565de4be… REG         2016 2016-05-11 19:10:00 closed          34890
#>  2 dc42dfe… 565de4be… REG         2016 2016-05-11 19:10:00 closed          34890
#>  3 dc42dfe… 565de4be… REG         2016 2016-05-11 19:10:00 closed          34890
#>  4 dc42dfe… 565de4be… REG         2016 2016-05-11 19:10:00 closed          34890
#>  5 dc42dfe… 565de4be… REG         2016 2016-05-11 19:10:00 closed          34890
#>  6 dc42dfe… 565de4be… REG         2016 2016-05-11 19:10:00 closed          34890
#>  7 252e491… 565de4be… REG         2016 2016-09-02 23:10:00 closed          12602
#>  8 252e491… 565de4be… REG         2016 2016-09-02 23:10:00 closed          12602
#>  9 252e491… 565de4be… REG         2016 2016-09-02 23:10:00 closed          12602
#> 10 252e491… 565de4be… REG         2016 2016-09-02 23:10:00 closed          12602
#> # … with 8,351 more rows, and 138 more variables: dayNight <chr>,
#> #   duration <chr>, durationMinutes <int>, awayTeamId <chr>,
#> #   awayTeamName <chr>, homeTeamId <chr>, homeTeamName <chr>, venueId <chr>,
#> #   venueName <chr>, venueSurface <chr>, venueCapacity <int>, venueCity <chr>,
#> #   venueState <chr>, venueZip <chr>, venueMarket <chr>,
#> #   venueOutfieldDistances <chr>, homeFinalRuns <int>, homeFinalHits <int>,
#> #   homeFinalErrors <int>, awayFinalRuns <int>, awayFinalHits <int>,
#> #   awayFinalErrors <int>, homeFinalRunsForInning <int>,
#> #   awayFinalRunsForInning <int>, inningNumber <int>, inningHalf <chr>,
#> #   inningEventType <chr>, inningHalfEventSequenceNumber <int>,
#> #   description <chr>, atBatEventType <chr>, atBatEventSequenceNumber <int>,
#> #   createdAt <dttm>, updatedAt <dttm>, status <chr>, outcomeId <chr>,
#> #   outcomeDescription <chr>, hitterId <chr>, hitterLastName <chr>,
#> #   hitterFirstName <chr>, hitterWeight <int>, hitterHeight <int>,
#> #   hitterBatHand <chr>, pitcherId <chr>, pitcherFirstName <chr>,
#> #   pitcherLastName <chr>, pitcherThrowHand <chr>, pitchType <chr>,
#> #   pitchTypeDescription <chr>, pitchSpeed <int>, pitchZone <int>,
#> #   pitcherPitchCount <int>, hitterPitchCount <int>, hitLocation <int>,
#> #   hitType <chr>, startingBalls <int>, startingStrikes <int>,
#> #   startingOuts <int>, balls <int>, strikes <int>, outs <int>,
#> #   rob0_start <chr>, rob0_end <int>, rob0_isOut <chr>, rob0_outcomeId <chr>,
#> #   rob0_outcomeDescription <chr>, rob1_start <chr>, rob1_end <int>,
#> #   rob1_isOut <chr>, rob1_outcomeId <chr>, rob1_outcomeDescription <chr>,
#> #   rob2_start <chr>, rob2_end <int>, rob2_isOut <chr>, rob2_outcomeId <chr>,
#> #   rob2_outcomeDescription <chr>, rob3_start <chr>, rob3_end <int>,
#> #   rob3_isOut <chr>, rob3_outcomeId <chr>, rob3_outcomeDescription <chr>,
#> #   is_ab <int>, is_ab_over <int>, is_hit <int>, is_on_base <int>,
#> #   is_bunt <int>, is_bunt_shown <int>, is_double_play <int>,
#> #   is_triple_play <int>, is_wild_pitch <int>, is_passed_ball <int>,
#> #   homeCurrentTotalRuns <int>, awayCurrentTotalRuns <int>, awayFielder1 <chr>,
#> #   awayFielder2 <chr>, awayFielder3 <chr>, awayFielder4 <chr>,
#> #   awayFielder5 <chr>, awayFielder6 <chr>, awayFielder7 <chr>,
#> #   awayFielder8 <chr>, …
```

<sup>Created on 2021-04-19 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

My thinking is:
1. Even though making `allow_fragments = FALSE` the default may break existing code, I would argue that in the cases described above, the code is already broken, the user just might not know it yet. If page_info$nrows = num_observations, there isn't a problem.
2. Grabbing the number of rows from the number of observations in the json files, even if `allow_fragments = TRUE`, makes it more obvious that there is a mismatch between the rows requested and the rows retrieved.

A note about looking at the json files: I recognize that my code essentially looks at the json files *twice*, and that ideally the lengths could be retrieved by the C++ code in `_bigquery_bq_parse_files` at the same time that the data are retrieved. It seemed best to leave that alone for a first pass, but I'm open to trying my hand at it with the blessing(s) of the maintainers.
