### PR TITLE
Add readr to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     Rcpp,
     rlang (>= 0.4.9),
     tibble,
-    readr
+    brio
 Suggests: 
     blob,
     covr,
@@ -50,6 +50,7 @@ Suggests:
     dbplyr (>= 1.3.0),
     dplyr (>= 0.7.0),
     hms,
+    readr,
     sodium,
     testthat (>= 2.1.0),
     withr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,8 @@ Imports:
     progress,
     Rcpp,
     rlang (>= 0.4.9),
-    tibble
+    tibble,
+    readr
 Suggests: 
     blob,
     covr,
@@ -49,7 +50,6 @@ Suggests:
     dbplyr (>= 1.3.0),
     dplyr (>= 0.7.0),
     hms,
-    readr,
     sodium,
     testthat (>= 2.1.0),
     withr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,20 +29,20 @@ Depends:
 Imports: 
     assertthat,
     bit64,
+    brio,
     curl,
     DBI,
     gargle (>= 1.2.0),
     glue (>= 1.3.0),
     httr,
-    lifecycle,
     jsonlite,
+    lifecycle,
     methods,
     prettyunits,
     progress,
     Rcpp,
     rlang (>= 0.4.9),
-    tibble,
-    brio
+    tibble
 Suggests: 
     blob,
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bigrquery (development version)
 
+brio is new in Imports, replacing the use of the Suggested package readr, in `bq_table_download()` (@AdeelK93, #462).
+
 # bigrquery 1.4.0
 
 * `bq_table_download()` has been heavily refactored (#412):

--- a/R/bq-download.R
+++ b/R/bq-download.R
@@ -337,8 +337,8 @@ bq_download_callback <- function(path, progress = NULL) {
 # Helpers for testing -----------------------------------------------------
 
 bq_parse_file <- function(fields, data) {
-  fields <- readr::read_file(fields)
-  data <- readr::read_file(data)
+  fields <- brio::read_file(fields)
+  data <- brio::read_file(data)
 
   bq_parse(fields, data)
 }


### PR DESCRIPTION
I have my own package that I'm working on, and it happens to include a `R CMD CHECK` test that calls a `bigrquery` function.

This test has been failing because `bigrquery` has `readr` in the Suggests section of the DESCRIPTION rather than the Imports. Fortunately this is a quick fix.

Here is an example of where `readr` is used in `bigrquery`:
https://github.com/r-dbi/bigrquery/blob/main/R/bq-download.R#L340