### PR TITLE
Return `wk::wkt()` with `geodesic = TRUE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Suggests:
     sodium,
     testthat (>= 2.1.0),
     withr,
-    wk (>= 0.3.2)
+    wk (>= 0.6.0)
 LinkingTo: 
     progress,
     rapidjsonr,

--- a/src/BqField.cpp
+++ b/src/BqField.cpp
@@ -183,6 +183,7 @@ public:
         check_namespace("wk", "GEOGRAPHY");
         Rcpp::CharacterVector out(n);
         out.attr("class") = Rcpp::CharacterVector::create("wk_wkt", "wk_vctr");
+        out.attr("geodesic") = true;
         return out;
       }
     case BQ_BYTES: {

--- a/tests/testthat/test-bq-download.R
+++ b/tests/testthat/test-bq-download.R
@@ -213,7 +213,7 @@ test_that("can convert geography type", {
   tb <- bq_project_query(bq_test_project(), sql, quiet = TRUE)
   df <- bq_table_download(tb)
 
-  expect_identical(df$geography, wk::wkt("POINT(30 10)"))
+  expect_identical(df$geography, wk::wkt("POINT(30 10)", geodesic = TRUE))
 })
 
 test_that("can convert bytes type", {

--- a/tests/testthat/test-bq-parse.R
+++ b/tests/testthat/test-bq-parse.R
@@ -177,9 +177,12 @@ test_that("can parse empty arrays", {
 test_that("can parse geography", {
   skip_if_not_installed("wk")
 
-  wkt <- wk::wkt("POINT (30 10)")
+  wkt <- wk::wkt("POINT (30 10)", geodesic = TRUE)
   expect_identical(bq_parse_single(as.character(wkt), "geography"), wkt)
-  expect_identical(bq_parse_single(NA_character_, "geography"), wk::wkt(NA_character_))
+  expect_identical(
+    bq_parse_single(NA_character_, "geography"),
+    wk::wkt(NA_character_, geodesic = TRUE)
+  )
 })
 
 test_that("can parse bytes", {

--- a/tests/testthat/test-bq-table.R
+++ b/tests/testthat/test-bq-table.R
@@ -172,7 +172,7 @@ test_that("can round-trip GEOGRAPHY", {
   skip_if_not_installed("wk")
 
   ds <- bq_test_dataset()
-  df <- tibble(geography = wk::wkt("POINT(30 10)"))
+  df <- tibble(geography = wk::wkt("POINT(30 10)", geodesic = TRUE))
 
   tb1 <- bq_table_create(
     bq_table(ds, "geography"),


### PR DESCRIPTION
Just a small addition to returning geography columns...the WKT that's returned by BigQuery has geodesic edges instead of planar ones. The latest wk update [introduced a way to mark these](https://fishandwhistle.net/post/2021/wk-version-0.6.0/#mark-geodesic-geometry-vectors) so they don't get interpreted incorrectly, and the forthcoming s2 update [will use this to provide safer conversions between wkt and s2 objects](https://github.com/r-spatial/s2/pull/155), which also assume geodesic edges. I imagine it's a small contingent using geography columns in BigQuery + R; however, this PR is an update to make that workflow seamless and safer.