### PR TITLE
make bq_table_create() friendlier by using x as default fields.

### DIFF
--- a/R/bq-table.R
+++ b/R/bq-table.R
@@ -56,16 +56,18 @@ NULL
 #' @param fields A [bq_fields] specification, or something coercible to it
 #'   (like a data frame).
 bq_table_create <- function(x, fields = NULL, ...) {
+  if (is.null(fields)){
+    fields <- x
+  }
   x <- as_bq_table(x)
 
   url <- bq_path(x$project, x$dataset, "")
   body <- list(
     tableReference = tableReference(x)
   )
-  if (!is.null(fields)) {
-    fields <- as_bq_fields(fields)
-    body$schema <- list(fields = as_json(fields))
-  }
+
+  fields <- as_bq_fields(fields)
+  body$schema <- list(fields = as_json(fields))
 
   bq_post(url, body = bq_body(body, ...))
 


### PR DESCRIPTION
This prevents unfriendly cast error messages from appearing, by defaulting to using the fields/coltypes from input dataframe x.

This SO thread inspired me to make this proposal.
https://stackoverflow.com/questions/53440116/bigrquery-forcefully-coerces-strings-to-integers-schema-is-a-string
( I myself took a while to be able to send data to BQ, like the original poster. )

This is my first PR. Please accept my apologies if anything is not appropriate!
Thank you for the wonderful package.