### PR TITLE
bq_perform_upload() friendlier fields handling. (use input df as fields)

### DIFF
--- a/R/bq-perform.R
+++ b/R/bq-perform.R
@@ -111,7 +111,8 @@ bq_perform_upload <- function(x, values,
                               create_disposition = "CREATE_IF_NEEDED",
                               write_disposition = "WRITE_EMPTY",
                               ...,
-                              billing = x$project
+                              billing = x$project,
+                              autodetect = FALSE
                               ) {
 
   x <- as_bq_table(x)
@@ -126,6 +127,10 @@ bq_perform_upload <- function(x, values,
     createDisposition = unbox(create_disposition),
     writeDisposition = unbox(write_disposition)
   )
+
+  if (is.null(fields) && autodetect == FALSE && is.data.frame(values)) {
+    fields <- as_bq_fields(values)
+  }
 
   if (!is.null(fields)) {
     fields <- as_bq_fields(fields)


### PR DESCRIPTION
use the input dataframe as the source of field specification.

pass autodetect = TRUE and it reverts to previous action, which is auto detection.
(which in my case was causing cast errors.)

This SO post gave me inspiration to propose this change.
https://stackoverflow.com/questions/53440116/bigrquery-forcefully-coerces-strings-to-integers-schema-is-a-string
( I myself started using bigrquery recently, and hit this error. Thought this action is friendlier to new users.)


This is my first PR, please accept my apologies if anything is inappropriate.
Thank you for the wonderful package!!