### PR TITLE
Make bigrquery work in projects without BQ access

### DIFF
--- a/R/bq-auth.R
+++ b/R/bq-auth.R
@@ -228,7 +228,7 @@ credentials_app_default_path <- function() {
 
 load_quota_project_id <- function() {
   path <- credentials_app_default_path()
-  if (!file_exists(path)) {
+  if (!fs::file_exists(path)) {
     return("")
   }
   info <- jsonlite::fromJSON(path, simplifyVector = FALSE)

--- a/R/bq-download.R
+++ b/R/bq-download.R
@@ -310,6 +310,10 @@ bq_download_chunk_handle <- function(x, begin = 0L, max_results = 1e4) {
     headers <- list()
   }
 
+  if (bq_has_quota_project_id()) {
+    headers[["X-Goog-User-Project"]] <- bq_quota_project_id()
+  }
+
   h <- curl::new_handle(url = url)
   curl::handle_setopt(h, useragent = bq_ua())
   curl::handle_setheaders(h, .list = headers)

--- a/R/bq-request.R
+++ b/R/bq-request.R
@@ -169,7 +169,7 @@ bq_upload <- function(url, parts, ..., query = list(), token = bq_token()) {
     url,
     parts = parts,
     token,
-    prep_headers()
+    prep_headers(),
     httr::user_agent(bq_ua()),
     ...,
     query = prepare_bq_query(query)


### PR DESCRIPTION
This is a fix for issue: https://github.com/r-dbi/bigrquery/issues/496

Basic idea is to open the application default credentials for the quota project ID (which is usually set by gcloud), and add it to the headers.