### PR TITLE
dbplyr compat part 2

### DIFF
--- a/tests/testthat/bq-job-errors.txt
+++ b/tests/testthat/bq-job-errors.txt
@@ -1,11 +1,7 @@
 > # One error
 > bq_dataset_query(ds, "SELECT 1 +", quiet = TRUE)
-Error: Job '' failed
+Error in bq_job_wait(job, quiet = quiet): Job '' failed
 x Syntax error: Unexpected end of script at [1:11] [invalidQuery]
 
 > # Multiple erros
 > bq_table_upload(tb, data.frame(x = 1, y = 1:5), quiet = TRUE)
-Error: Job '' failed
-x Error while reading data, error message: JSON processing encountered too many errors, giving up. Rows: 1; errors: 1; max bad: 0; error percent: 0 [invalid]
-x Error while reading data, error message: JSON parsing error in row starting at position 0: Could not convert value to string. Field: y; Value: 1 [invalid]
-

--- a/tests/testthat/test-bq-job.R
+++ b/tests/testthat/test-bq-job.R
@@ -13,6 +13,7 @@ test_that("informative errors on failure", {
   fields <- bq_fields(list(bq_field("x", "integer"), bq_field("y", "string")))
   bq_mtcars <- bq_table_create(tb, fields = fields)
 
+  # TODO update the `Multiple errors` test case
   verify_output(test_path("bq-job-errors.txt"), {
     "One error"
     bq_dataset_query(ds, "SELECT 1 +", quiet = TRUE)

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -1,6 +1,9 @@
 test_that("historical API continues to work", {
+  rlang::reset_warning_verbosity("BigQueryConnection-edition")
   src <- src_bigquery(bq_test_project(), "basedata")
-  x <- dplyr::tbl(src, "mtcars")
+
+  # old dbplyr interface warning
+  expect_warning(x <- dplyr::tbl(src, "mtcars"))
 
   expect_s3_class(x, "tbl")
   expect_true("cyl" %in% dbplyr::op_vars(x))


### PR DESCRIPTION
There were 3 issues:

1. The warning about the old dbplyr interface. I simply wrapped this in `expect_warning()` as I won't migrate bigrquery to dbplyr edition 2 (as I'm not using bigquery at all...).
2. The expected errros in `bq-job-errors.txt`. One changed slightly due to rlang. The other does not error anymore. Probably bigquery does not throw an error anymore. I added a note that this should be updated but this should be someone more experienced with bigquery.
3. The last error seems to be random. `bq_test_dataset()` is successfully called  a couple of times before and I cannot reproduce it either.