### PR TITLE
Modify the bq_perform_query so that labels argument is respected

### DIFF
--- a/R/bq-perform.R
+++ b/R/bq-perform.R
@@ -281,11 +281,12 @@ bq_perform_query <- function(query, billing,
   }
 
   url <- bq_path(billing, jobs = "")
-  body <- list(configuration = list(query = query))
+    
+  body <- list(configuration = bq_body(list(query = query), ...))
 
   res <- bq_post(
     url,
-    body = bq_body(body, ...),
+    body = body,
     query = list(fields = "jobReference")
   )
   as_bq_job(res$jobReference)
@@ -314,11 +315,10 @@ bq_perform_query_dry_run <- function(query, billing,
   }
 
   url <- bq_path(billing, jobs = "")
-  body <- list(configuration = list(query = query, dryRun = unbox(TRUE)))
-
+  body <- list(configuration = bq_body(list(query = query, dryRun = unbox(TRUE)), ... ))
   res <- bq_post(
     url,
-    body = bq_body(body, ...),
+    body = body,
     query = list(fields = "statistics")
   )
   bytes <- as.numeric(res$statistics$query$totalBytesProcessed)


### PR DESCRIPTION
Cost tracking is very important for BigQuery. This is done through labeling, but currently bigrquery does not support adding labels to the queries. 

This PR passess the ... argument to job configuration so if you add labels argument to the bq_project_query it is passed to BigQuery API and the job gets labeled

```
bq_project_query(bq_test_project(), "SELECT count(*) FROM publicdata.samples.natality", labels = list(test = test))
```

This query will get the label test with value test. 

I've tested internally and can confirm that this approach works. However this is a more of a proposal how to do that. Ideally either labels should be an argument which can be passed to all the high level functions, or there should be more clarity where argument ... is actually passed. 

Looking at the documentation for https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert which bq_perform_query posts to, the body should be a Job object, which is documented here https://cloud.google.com/bigquery/docs/reference/rest/v2/Job. Looking at that documentation the only setable argument is configuration, hence additional parameters should be passed there.
