### PR TITLE
different fix for #509

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -110,7 +110,7 @@ collect.tbl_BigQueryConnection <- function(x, ...,
 
   if (op_can_download(x)) {
     lq <- x$lazy_query
-    name <- op_table(x, con)
+    name <- op_table(lq, con)
     tb <- as_bq_table(con, name)
     n <- min(op_rows(x$lazy_query), n)
   } else {


### PR DESCRIPTION
Alternative fix for #509, but different than #512.  I think this may be a safer fix as it does not change the behavior of `op_table.lazy_select_query`, but does change behavior, but only in `collect.tbl_BigQueryConnection`, and when `op_can_download` returns a `TRUE` for the table. 

Also, I'll copy my explanation from #512:
Looking into the code, I think the real error is at
https://github.com/r-dbi/bigrquery/blob/3f187b20cd566e4c27e42ae1124b893f3fc53bb2/R/dplyr.R#L113.  The reason I think that is that `lq` is defined, but never used, so I think the code change is supposed to be:
```r
name <- op_table(lq, con)
```