### PR TITLE
Align Google APIs URLs with Discovery docs per #541 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
 # bigrquery (development version)
 
-# bigrquery 1.4.3
-
 * Align Google APIs URLs to Google Cloud Discovery docs. This enables support for Private and Restricted Google APIs configurations.
+  (@husseyd, #541)
   - `R/bq-request.R`
     - Substitute `https://bigquery.googleapis.com` for `https://www.googleapis.com`
   - `R/gs-object.R`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # bigrquery (development version)
 
+# bigrquery 1.4.3
+
+* Align Google APIs URLs to Google Cloud Discovery docs. This enables support for Private and Restricted Google APIs configurations.
+  - `R/bq-request.R`
+    - Substitute `https://bigquery.googleapis.com` for `https://www.googleapis.com`
+  - `R/gs-object.R`
+    - Substitute `https://storage.googleapis.com` for `https://www.googleapis.com`
+
 # bigrquery 1.4.2
 
 * Sync up with the current release of gargle (1.4.0). Recently gargle

--- a/R/bq-request.R
+++ b/R/bq-request.R
@@ -1,5 +1,5 @@
-base_url <- "https://www.googleapis.com/bigquery/v2/"
-upload_url <- "https://www.googleapis.com/upload/bigquery/v2/"
+base_url <- "https://bigquery.googleapis.com/bigquery/v2/"
+upload_url <- "https://bigquery.googleapis.com/upload/bigquery/v2/"
 
 prepare_bq_query <- function(query) {
   api_key <- Sys.getenv("BIGRQUERY_API_KEY")

--- a/R/gs-object.R
+++ b/R/gs-object.R
@@ -22,13 +22,13 @@ print.gs_object <- function(x, ...) {
 }
 
 gs_object_delete <- function(x, token = bq_token()) {
-  url <- glue_data(x, "https://www.googleapis.com/storage/v1/b/{bucket}/o/{object}")
+  url <- glue_data(x, "https://storage.googleapis.com/storage/v1/b/{bucket}/o/{object}")
   req <- httr::DELETE(url, token, httr::user_agent(bq_ua()))
   process_request(req)
 }
 
 gs_object_exists <- function(x, token = bq_token()) {
-  url <- glue_data(x, "https://www.googleapis.com/storage/v1/b/{bucket}/o/{object}")
+  url <- glue_data(x, "https://storage.googleapis.com/storage/v1/b/{bucket}/o/{object}")
   req <- httr::GET(url, token, httr::user_agent(bq_ua()))
   req$status_code != 404
 }


### PR DESCRIPTION
Align Google APIs URLs with Discovery docs per #541 

* Align Google APIs URLs to Google Cloud Discovery docs. This enables support for Private and Restricted Google APIs configurations.
  - `R/bq-request.R`
    - Substitute `https://bigquery.googleapis.com` for `https://www.googleapis.com`
  - `R/gs-object.R`
    - Substitute `https://storage.googleapis.com` for `https://www.googleapis.com`
  - No updates to OAuth scope URLs 
    - (E.G. `https://www.googleapis.com/auth...`). These do not require change.

* Update NEWS.md and bump version to 1.4.3
