### PR TITLE
dbFetch() respects the quiet parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bigrquery (development version)
 
+* `dbFetch()` now respects the `quiet` setting from the connection (#463).
+
 * Added a translation for `runif(n())`. This fixes the translation for
   `slice_sample()` (@mgirlich, #448).
 

--- a/R/bq-test.R
+++ b/R/bq-test.R
@@ -132,6 +132,8 @@ random_name <- function(n = 10) {
 
 is_testing <- function() identical(Sys.getenv("TESTTHAT"), "true")
 
+is_snapshot <- function() identical(Sys.getenv("TESTTHAT_IS_SNAPSHOT"), "true")
+
 skip_if_no_auth <- function() {
   testthat::skip_if_not(bq_has_token(), "Authentication not available")
 }

--- a/R/dbi-result.R
+++ b/R/dbi-result.R
@@ -116,7 +116,8 @@ setMethod(
       n_max = n,
       start_index = res@cursor$cur(),
       page_size = res@page_size,
-      bigint = res@bigint
+      bigint = res@bigint,
+      quiet = res@quiet
     )
     res@cursor$adv(n)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,7 +7,7 @@ as_df <- function(x) {
 
 bq_quiet <- function(x) {
   if (is.na(x)) {
-    !is_interactive()
+    !(is_interactive() || is_snapshot())
   } else {
     x
   }
@@ -77,3 +77,4 @@ print.bq_bytes <- function(x, ...) {
   cat_line(prettyunits::pretty_bytes(unclass(x)))
 }
 # nocov end
+

--- a/tests/testthat/_snaps/bq-download.md
+++ b/tests/testthat/_snaps/bq-download.md
@@ -2,6 +2,8 @@
 
     Code
       bq_table_download(tb, n_max = 35000, page_size = 35000, bigint = "integer64")
+    Message
+      Downloading first chunk of data.
     Condition
       Error in `bq_table_download()`:
       ! First chunk is incomplete:

--- a/tests/testthat/_snaps/dbi-result.md
+++ b/tests/testthat/_snaps/dbi-result.md
@@ -1,3 +1,16 @@
+# can retrieve query in pieces and that quiet is respected
+
+    Code
+      df <- DBI::dbFetch(res, 10)
+    Message
+      Downloading first chunk of data.
+      First chunk includes all requested rows.
+
+---
+
+    Code
+      df <- DBI::dbFetch(res, -1)
+
 # can get metadata
 
     Code

--- a/tests/testthat/test-dbi-result.R
+++ b/tests/testthat/test-dbi-result.R
@@ -20,7 +20,7 @@ test_that("can retrieve without dataset", {
   expect_equal(df, tibble(count = 32L))
 })
 
-test_that("can retrieve query in pieces", {
+test_that("can retrieve query in pieces and that quiet is respected", {
   con <- DBI::dbConnect(
     bigquery(),
     project = bq_test_project(),
@@ -30,12 +30,15 @@ test_that("can retrieve query in pieces", {
   res <- DBI::dbSendQuery(con, "SELECT cyl, mpg FROM mtcars")
   expect_equal(DBI::dbGetRowCount(res), 0L)
 
-  df <- DBI::dbFetch(res, 10)
+  res@quiet <- FALSE
+  expect_snapshot(df <- DBI::dbFetch(res, 10))
+
   expect_equal(nrow(df), 10)
   expect_false(DBI::dbHasCompleted(res))
   expect_equal(DBI::dbGetRowCount(res), 10L)
 
-  df <- DBI::dbFetch(res, -1)
+  res@quiet <- TRUE
+  expect_snapshot(df <- DBI::dbFetch(res, -1))
   expect_equal(nrow(df), 22)
   expect_true(DBI::dbHasCompleted(res))
 })


### PR DESCRIPTION
And default to verbose output when snapshotting.

Fixes #463