### PR TITLE
Raise minimum `gargle` version to 1.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     clock,
     curl,
     DBI,
-    gargle (>= 1.4.0),
+    gargle (>= 1.5.0),
     httr,
     jsonlite,
     lifecycle,


### PR DESCRIPTION
The [use of `gargle::secret_has_key()`](https://github.com/r-dbi/bigrquery/blob/42dd4d2969600071ad7ccb8b11b052a2daae5d52/R/bq-auth.R#L101-L103) entails `gargle >=1.5.0` (see [v1.4.0...v1.5.0 diff](https://github.com/r-lib/gargle/compare/v1.4.0...v1.5.0#diff-b6b6854a02ae177f8860f49654ff250c1554d021ae434b6efdbe99d00bdc6055)). This PR updates DESCRIPTION to reflect that.