### PR TITLE
docs: Update example to highlight I() for nested table identifier

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -20,7 +20,7 @@
 #' # set up for billing
 #' con <- DBI::dbConnect(bigquery(), project = bq_test_project())
 #'
-#' shakespeare <- con %>% tbl("publicdata.samples.shakespeare")
+#' shakespeare <- con %>% tbl(I("publicdata.samples.shakespeare"))
 #' shakespeare
 #' shakespeare %>%
 #'   group_by(word) %>%

--- a/man/src_bigquery.Rd
+++ b/man/src_bigquery.Rd
@@ -31,7 +31,7 @@ library(dplyr)
 # set up for billing
 con <- DBI::dbConnect(bigquery(), project = bq_test_project())
 
-shakespeare <- con \%>\% tbl("publicdata.samples.shakespeare")
+shakespeare <- con \%>\% tbl(I("publicdata.samples.shakespeare"))
 shakespeare
 shakespeare \%>\%
   group_by(word) \%>\%

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -20,6 +20,17 @@ test_that("can work with literal SQL", {
   expect_true("fips_code" %in% dbplyr::op_vars(x))
 })
 
+test_that("can work with nested table identifier", {
+  con_us <- DBI::dbConnect(
+    bigquery(),
+    project = "bigquery-public-data",
+    billing = bq_test_project()
+  )
+
+  expect_s3_class(dplyr::collect(head(dplyr::tbl(con_us, I("utility_us.country_code_iso")))), "tbl_df")
+  expect_error(dplyr::collect(head(dplyr::tbl(con_us, "utility_us.country_code_iso"))), "tbl_df")
+})
+
 test_that("can copy_to", {
   ds <- bq_test_dataset()
   con <- DBI::dbConnect(ds)


### PR DESCRIPTION
This pull request updates the example in the `dplyr.R` and `src_bigquery.Rd` files to highlight the use of the `I()` function for nested table identifiers.
It also adds unit tests for nested table identifier.

https://www.tidyverse.org/blog/2024/04/dbplyr-2-5-0/

Resolves #605 