### PR TITLE
Fix bq_table_upload when source_format is undefined

### DIFF
--- a/R/bq-perform.R
+++ b/R/bq-perform.R
@@ -125,7 +125,7 @@ bq_perform_upload <- function(x, values,
     cli::cli_abort("{.arg values} must be a data frame.")
   }
   fields <- as_bq_fields(fields)
-  arg_match(source_format)
+  source_format <- arg_match(source_format)
   check_string(create_disposition)
   check_string(write_disposition)
   check_string(billing)


### PR DESCRIPTION
Hi @hadley,

This pull request aims to address the error encountered in the live API. This error occurs because when source_format is not defined, a vector of length 2 is being passed to unbox. Therefore, the correction for this error involves updating the source_format variable when arg_match is performed.

Regards,