### PR TITLE
Skip test requiring recent dbplyr

### DIFF
--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -174,6 +174,7 @@ test_that("all BigQuery tbls share the same src", {
 })
 
 test_that("runif is correctly translated", {
+  skip_if_not_installed("dbplyr", "2.4.0")
   expect_equal(
     dbplyr::translate_sql(runif(n()), con = simulate_bigrquery()),
     dbplyr::sql("RAND()")


### PR DESCRIPTION
`sql_runif()` was only added in 2.4.0:

https://github.com/tidyverse/dbplyr/blob/860bd6adf988a2b039485030d234eba05ee46a3c/NEWS.md?plain=1#L199