### PR TITLE
Update the required version of nanoparquet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     prettyunits,
     rlang (>= 1.1.0),
     tibble,
-    nanoparquet (> 0.2.0)
+    nanoparquet (>= 0.3.0)
 Suggests:
     blob,
     covr,
@@ -41,8 +41,6 @@ Suggests:
     testthat (>= 3.1.5),
     wk (>= 0.3.2),
     withr
-Remotes:
-    r-lib/nanoparquet
 LinkingTo: 
     cli,
     cpp11,


### PR DESCRIPTION
Hi @hadley,

This pull request aims to update the nanoparquet version to 0.3.0 since it is now available on CRAN.

Regards,