### PR TITLE
Update bq_perform_extract documentation

### DIFF
--- a/R/bq-perform.R
+++ b/R/bq-perform.R
@@ -42,12 +42,16 @@ NULL
 #'   up to 1 Gb of data per file. Use a wild card URI (e.g.
 #'   `gs://[YOUR_BUCKET]/file-name-*.json`) to automatically create any
 #'   number of files.
-#' @param destination_format The exported file format. Possible values
-#'   include "CSV", "NEWLINE_DELIMITED_JSON" and "AVRO". Tables with nested or
-#'   repeated fields cannot be exported as CSV.
-#' @param compression The compression type to use for exported files. Possible
-#'   values include "GZIP", "DEFLATE", "SNAPPY", and "NONE". "DEFLATE" and
-#'   "SNAPPY" are only supported for Avro.
+#' @param destination_format The exported file format:
+#'   * For CSV files, specify "CSV" (Nested and repeated data is not supported).
+#'   * For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON".
+#'   * For Avro, specify "AVRO".
+#'   * For parquet, specify "PARQUET".
+#' @param compression The compression type to use for exported files:
+#'   * For CSV files: "GZIP" or "NONE".
+#'   * For newline-delimited JSON: "GZIP" or "NONE".
+#'   * For Avro: "DEFLATE", "SNAPPY" or "NONE".
+#'   * For parquet: "SNAPPY", "GZIP", "ZSTD" or "NONE".
 #' @param ... Additional arguments passed on to the underlying API call.
 #'   snake_case names are automatically converted to camelCase.
 #' @param print_header Whether to print out a header row in the results.

--- a/man/api-perform.Rd
+++ b/man/api-perform.Rd
@@ -83,13 +83,21 @@ up to 1 Gb of data per file. Use a wild card URI (e.g.
 \verb{gs://[YOUR_BUCKET]/file-name-*.json}) to automatically create any
 number of files.}
 
-\item{destination_format}{The exported file format. Possible values
-include "CSV", "NEWLINE_DELIMITED_JSON" and "AVRO". Tables with nested or
-repeated fields cannot be exported as CSV.}
+\item{destination_format}{The exported file format:
+\itemize{
+\item For CSV files, specify "CSV" (Nested and repeated data is not supported).
+\item For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON".
+\item For Avro, specify "AVRO".
+\item For parquet, specify "PARQUET".
+}}
 
-\item{compression}{The compression type to use for exported files. Possible
-values include "GZIP", "DEFLATE", "SNAPPY", and "NONE". "DEFLATE" and
-"SNAPPY" are only supported for Avro.}
+\item{compression}{The compression type to use for exported files:
+\itemize{
+\item For CSV files: "GZIP" or "NONE".
+\item For newline-delimited JSON: "GZIP" or "NONE".
+\item For Avro: "DEFLATE", "SNAPPY" or "NONE".
+\item For parquet: "SNAPPY", "GZIP", "ZSTD" or "NONE".
+}}
 
 \item{...}{Additional arguments passed on to the underlying API call.
 snake_case names are automatically converted to camelCase.}


### PR DESCRIPTION
Hi @hadley,

This pull request aims to update the documentation of the ` bq_perfom_extract ` function, as the BigQuery documentation (https://cloud.google.com/bigquery/docs/exporting-data) specifies that the Parquet format is supported. However, this format is not listed as supported in the documentation of this library.

Regards,