### PR TITLE
Update the required version of nanoparquet (>3.0.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     prettyunits,
     rlang (>= 1.1.0),
     tibble,
-    nanoparquet (>= 0.3.0)
+    nanoparquet (> 0.3.1)
 Suggests:
     blob,
     covr,
@@ -41,6 +41,8 @@ Suggests:
     testthat (>= 3.1.5),
     wk (>= 0.3.2),
     withr
+Remotes:
+    r-lib/nanoparquet    
 LinkingTo: 
     cli,
     cpp11,
@@ -51,7 +53,7 @@ Config/testthat/parallel: TRUE
 Config/testthat/start-first: bq-table, dplyr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Collate: 
     'bigrquery-package.R'
     'bq-auth.R'


### PR DESCRIPTION
Hi @hadley,

This pull request aims to update the nanoparquet version to >0.3.1 since a bug has been identified https://github.com/r-lib/nanoparquet/issues/77 which has already been fixed.

Regards,