### PR TITLE
Use "bigrquery.quiet" in more bq_ functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bigrquery (development version)
 
+* Check `getOption("bigrquery.quiet")` option in more `bq_*` functions (#663).
+
 # bigrquery 1.6.1
 
 * Fix test failure on CRAN.

--- a/R/bq-download.R
+++ b/R/bq-download.R
@@ -77,7 +77,7 @@ bq_table_download <-
     page_size = NULL,
     start_index = 0L,
     max_connections = 6L,
-    quiet = NA,
+    quiet = getOption("bigrquery.quiet", NA),
     bigint = c("integer", "integer64", "numeric", "character"),
     api = c("json", "arrow"),
     billing = x$project

--- a/R/bq-query.R
+++ b/R/bq-query.R
@@ -46,7 +46,7 @@ bq_project_query <- function(
   query,
   destination_table = NULL,
   ...,
-  quiet = NA
+  quiet = getOption("bigrquery.quiet", NA)
 ) {
   check_string(x)
   query <- as_query(query)
@@ -73,7 +73,7 @@ bq_dataset_query <- function(
   destination_table = NULL,
   ...,
   billing = NULL,
-  quiet = NA
+  quiet = getOption("bigrquery.quiet", NA)
 ) {
   x <- as_bq_dataset(x)
   query <- as_query(query)

--- a/R/bq-table.R
+++ b/R/bq-table.R
@@ -123,7 +123,7 @@ bq_table_delete <- function(x) {
 #' @rdname api-table
 #' @inheritParams bq_perform_copy
 #' @param dest Source and destination [bq_table]s.
-bq_table_copy <- function(x, dest, ..., quiet = NA) {
+bq_table_copy <- function(x, dest, ..., quiet = getOption("bigrquery.quiet", NA)) {
   x <- as_bq_table(x)
   dest <- as_bq_table(dest)
 
@@ -136,7 +136,7 @@ bq_table_copy <- function(x, dest, ..., quiet = NA) {
 #' @export
 #' @rdname api-table
 #' @inheritParams api-perform
-bq_table_upload <- function(x, values, ..., quiet = NA) {
+bq_table_upload <- function(x, values, ..., quiet = getOption("bigrquery.quiet", NA)) {
   x <- as_bq_table(x)
 
   job <- bq_perform_upload(x, values, ...)
@@ -147,7 +147,7 @@ bq_table_upload <- function(x, values, ..., quiet = NA) {
 
 #' @export
 #' @rdname api-table
-bq_table_save <- function(x, destination_uris, ..., quiet = NA) {
+bq_table_save <- function(x, destination_uris, ..., quiet = getOption("bigrquery.quiet", NA)) {
   x <- as_bq_table(x)
 
   job <- bq_perform_extract(x, destination_uris = destination_uris, ...)
@@ -158,7 +158,7 @@ bq_table_save <- function(x, destination_uris, ..., quiet = NA) {
 
 #' @export
 #' @rdname api-table
-bq_table_load <- function(x, source_uris, ..., quiet = NA) {
+bq_table_load <- function(x, source_uris, ..., quiet = getOption("bigrquery.quiet", NA)) {
   x <- as_bq_table(x)
 
   job <- bq_perform_load(x, source_uris = source_uris, ...)

--- a/man/api-table.Rd
+++ b/man/api-table.Rd
@@ -30,13 +30,13 @@ bq_table_exists(x)
 
 bq_table_delete(x)
 
-bq_table_copy(x, dest, ..., quiet = NA)
+bq_table_copy(x, dest, ..., quiet = getOption("bigrquery.quiet", NA))
 
-bq_table_upload(x, values, ..., quiet = NA)
+bq_table_upload(x, values, ..., quiet = getOption("bigrquery.quiet", NA))
 
-bq_table_save(x, destination_uris, ..., quiet = NA)
+bq_table_save(x, destination_uris, ..., quiet = getOption("bigrquery.quiet", NA))
 
-bq_table_load(x, source_uris, ..., quiet = NA)
+bq_table_load(x, source_uris, ..., quiet = getOption("bigrquery.quiet", NA))
 
 bq_table_patch(x, fields)
 }

--- a/man/bq_query.Rd
+++ b/man/bq_query.Rd
@@ -6,7 +6,7 @@
 \alias{bq_dataset_query}
 \title{Submit query to BigQuery}
 \usage{
-bq_project_query(x, query, destination_table = NULL, ..., quiet = NA)
+bq_project_query(x, query, destination_table = NULL, ..., quiet = getOption("bigrquery.quiet", NA))
 
 bq_dataset_query(
   x,
@@ -14,7 +14,7 @@ bq_dataset_query(
   destination_table = NULL,
   ...,
   billing = NULL,
-  quiet = NA
+  quiet = getOption("bigrquery.quiet", NA)
 )
 }
 \arguments{

--- a/man/bq_table_download.Rd
+++ b/man/bq_table_download.Rd
@@ -10,7 +10,7 @@ bq_table_download(
   page_size = NULL,
   start_index = 0L,
   max_connections = 6L,
-  quiet = NA,
+  quiet = getOption("bigrquery.quiet", NA),
   bigint = c("integer", "integer64", "numeric", "character"),
   api = c("json", "arrow"),
   billing = x$project


### PR DESCRIPTION
Changes several function default values from `quiet=NA` to `quiet=getOption("bigrquery.quiet", NA)`.

Includes NEWS and code.