### PR TITLE
Add `params=` to `dbExecute` S3 method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # bigrquery (development version)
 
-* Add `params=` support to the `dbExecute()` method. Additionally, error if
-  both `parameters=` (normal within `bigrquery`) and `params=` (DBI standard) are supplied (#663).
-* Check `getOption("bigrquery.quiet")` option in more `bq_*` functions (#663).
+* `dbExecute()` gains `params=` support (@r2evans, #667).
+* `dbExecute()` and `dbSendQuery()` error if you accidentally use `parameters`  (@r2evans, #667).
+* Check `getOption("bigrquery.quiet")` option in more `bq_*` functions (@r2evans, #663).
 
 # bigrquery 1.6.1
 

--- a/R/dbi-connection.R
+++ b/R/dbi-connection.R
@@ -85,14 +85,14 @@ setMethod(
 
 #' @rdname DBI
 #' @inheritParams DBI::dbSendQuery
-#' @param params,parameters Named list of parameters match to query parameters.
+#' @param params Named list of parameters match to query parameters.
 #'   Parameter `x` will be matched to placeholder `@x`.
 #' @export
 setMethod(
   "dbSendQuery",
   c("BigQueryConnection", "character"),
-  function(conn, statement, ..., params = NULL, parameters = NULL) {
-    params <- check_params(params, parameters)
+  function(conn, statement, ..., params = NULL) {
+    check_for_parameters(..., call = quote(dbSendQuery()))
     BigQueryResult(conn, statement, params = params)
   }
 )
@@ -103,10 +103,10 @@ setMethod(
 setMethod(
   "dbExecute",
   c("BigQueryConnection", "character"),
-  function(conn, statement, ..., params = NULL, parameters = NULL) {
+  function(conn, statement, ..., params = NULL) {
     ds <- if (!is.null(conn@dataset)) as_bq_dataset(conn)
 
-    params <- check_params(params, parameters)
+    check_for_parameters(..., call = quote(dbExecute()))
     job <- bq_perform_query(
       statement,
       billing = conn@billing,
@@ -122,21 +122,11 @@ setMethod(
   }
 )
 
-check_params <- function(
-  params = NULL,
-  parameters = NULL,
-  call = caller_env()
-) {
-  if (!is.null(params) && !is.null(parameters)) {
-    cli::cli_abort(
-      "Only one of {.arg params} and {.arg parameters} may be supplied.",
-      call = call
-    )
-  } else if (is.null(params)) {
-    parameters
-  } else {
-    params
+check_for_parameters <- function(..., parameters = NULL, call = caller_env()) {
+  if (is.null(parameters)) {
+    return()
   }
+  cli::cli_abort("Use {.arg params} not {.arg parameters}.", call = call)
 }
 
 #' @rdname DBI

--- a/man/DBI.Rd
+++ b/man/DBI.Rd
@@ -75,9 +75,9 @@
 
 \S4method{dbDisconnect}{BigQueryConnection}(conn, ...)
 
-\S4method{dbSendQuery}{BigQueryConnection,character}(conn, statement, ..., params = NULL, parameters = NULL)
+\S4method{dbSendQuery}{BigQueryConnection,character}(conn, statement, ..., params = NULL)
 
-\S4method{dbExecute}{BigQueryConnection,character}(conn, statement, ..., params = NULL, parameters = NULL)
+\S4method{dbExecute}{BigQueryConnection,character}(conn, statement, ..., params = NULL)
 
 \S4method{dbQuoteString}{BigQueryConnection,character}(conn, x, ...)
 
@@ -206,7 +206,7 @@ i.e. \link[DBI:DBIDriver-class]{DBI::DBIDriver}, \link[DBI:DBIConnection-class]{
 
 \item{statement}{a character string containing SQL.}
 
-\item{params, parameters}{Named list of parameters match to query parameters.
+\item{params}{Named list of parameters match to query parameters.
 Parameter \code{x} will be matched to placeholder \verb{@x}.}
 
 \item{x}{A character vector to quote as string.}

--- a/tests/testthat/_snaps/dbi-connection.md
+++ b/tests/testthat/_snaps/dbi-connection.md
@@ -35,6 +35,19 @@
       Error in `DBI::dbWriteTable()`:
       ! `temporary = FALSE` not supported by bigrquery.
 
+# can't use parameters
+
+    Code
+      DBI::dbGetQuery(con, "SELECT @x AS value", parameters = list(x = 1))
+    Condition
+      Error in `dbSendQuery()`:
+      ! Use `params` not `parameters`.
+    Code
+      DBI::dbExecute(con, "DELETE table WHERE x <= @x", parameters = list(x = 1))
+    Condition
+      Error in `dbExecute()`:
+      ! Use `params` not `parameters`.
+
 # dataset is optional
 
     Code

--- a/tests/testthat/test-dbi-connection.R
+++ b/tests/testthat/test-dbi-connection.R
@@ -102,7 +102,7 @@ test_that("can execute a query", {
   expect_equal(out, 2)
 })
 
-test_that("can use parameters", {
+test_that("can use params", {
   con <- DBI::dbConnect(bigquery(), project = bq_test_project())
 
   # in dbGetQuery
@@ -122,12 +122,17 @@ test_that("can use parameters", {
   expect_equal(out, 2)
 })
 
-test_that("check check_params() handling", {
-  expect_equal(check_params(NULL, NULL), NULL)
-  expect_equal(check_params(parameters = list(x = 1)), list(x = 1))
-  expect_equal(check_params(params = list(x = 2)), list(x = 2))
-  expect_snapshot(check_params(list(x = 1), list(x = 2)), error = TRUE)
+
+test_that("can't use parameters", {
+  con <- DBI::dbConnect(bigquery(), project = bq_test_project())
+
+  # in dbGetQuery
+  expect_snapshot(error = TRUE, {
+    DBI::dbGetQuery(con, "SELECT @x AS value", parameters = list(x = 1))
+    DBI::dbExecute(con, "DELETE table WHERE x <= @x", parameters = list(x = 1))
+  })
 })
+
 
 test_that("can use DBI::Id()", {
   ds <- bq_test_dataset()


### PR DESCRIPTION
Two fixes:

- while `dbGetQuery(con, query, params=)` works, `dbExecute(con, query, params=)` does not; and
- prevents both `params=` and `parameters=` from being passed as `BigQueryResult(params=)`

Includes NEWS, code, and unit-tests.