### PR TITLE
Adding job labels for FinOps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # bigrquery (development version)
 
+* `bq_perform_query()` and friends gain a `labels` argument that attaches [BigQuery labels](https://cloud.google.com/bigquery/docs/labels-intro) to the resulting job, useful for cost allocation. `dbConnect()` gains a matching `labels` argument that is forwarded to every job run on the connection. Defaults to `getOption("bigrquery.labels")` (@JulianUmbhau, #673).
 * BigQuery error messages containing `{` or `}` are no longer mistaken for cli expressions, so the underlying server message is shown instead of a cli parse failure (#677).
 * `bq_perform_upload()` and friends now default to 22 digits of accuracy, and now allow you to change this value with the new `json_digits` argument.
 * Always upload `POSIXt` objects with 6 digits (i.e. microsecond) precision  (#660). 

--- a/R/bq-parse.R
+++ b/R/bq-parse.R
@@ -1,6 +1,6 @@
 bq_parse_single <- function(value, type, ...) {
   field <- bq_field("", type, ...)
-  field_j <- jsonlite::toJSON(as_json(field), auto_unbox = TRUE)
+  field_j <- jsonlite::toJSON(as_json(field))
   value_j <- jsonlite::toJSON(value, auto_unbox = TRUE)
 
   bq_field_init(field_j, value_j)

--- a/R/bq-parse.R
+++ b/R/bq-parse.R
@@ -1,6 +1,6 @@
 bq_parse_single <- function(value, type, ...) {
   field <- bq_field("", type, ...)
-  field_j <- jsonlite::toJSON(as_json(field))
+  field_j <- jsonlite::toJSON(as_json(field), auto_unbox = TRUE)
   value_j <- jsonlite::toJSON(value, auto_unbox = TRUE)
 
   bq_field_init(field_j, value_j)

--- a/R/bq-perform.R
+++ b/R/bq-perform.R
@@ -168,7 +168,7 @@ bq_perform_upload <- function(
   metadata <- bq_body(metadata, ...)
   metadata <- list(
     "type" = "application/json; charset=UTF-8",
-    "content" = jsonlite::toJSON(metadata, auto_unbox = TRUE, pretty = TRUE)
+    "content" = jsonlite::toJSON(metadata, auto_unbox = TRUE, pretty = TRUE, digits = json_digits)
   )
 
   if (source_format == "NEWLINE_DELIMITED_JSON") {

--- a/R/bq-perform.R
+++ b/R/bq-perform.R
@@ -72,6 +72,8 @@ bq_perform_extract <- function(
   check_bool(print_header)
   check_string(billing)
 
+  labels <- check_labels(getOption("bigrquery.labels"))
+
   url <- bq_path(billing, jobs = "")
   body <- list(
     configuration = list(
@@ -81,7 +83,8 @@ bq_perform_extract <- function(
         destinationFormat = unbox(destination_format),
         compression = unbox(compression),
         printHeader = unbox(print_header)
-      )
+      ),
+      labels = labels
     )
   )
 
@@ -140,6 +143,8 @@ bq_perform_upload <- function(
   check_string(billing)
   json_digits <- check_digits(json_digits)
 
+  labels <- check_labels(getOption("bigrquery.labels"))
+
   load <- list(
     sourceFormat = unbox(source_format),
     destinationTable = tableReference(x),
@@ -154,11 +159,16 @@ bq_perform_upload <- function(
     load$autodetect <- unbox(TRUE)
   }
 
-  metadata <- list(configuration = list(load = load))
+  metadata <- list(
+    configuration = list(
+      load = load,
+      labels = labels
+    )
+  )
   metadata <- bq_body(metadata, ...)
   metadata <- list(
     "type" = "application/json; charset=UTF-8",
-    "content" = jsonlite::toJSON(metadata, pretty = TRUE, digits = json_digits)
+    "content" = jsonlite::toJSON(metadata, auto_unbox = TRUE, pretty = TRUE)
   )
 
   if (source_format == "NEWLINE_DELIMITED_JSON") {
@@ -261,6 +271,8 @@ bq_perform_load <- function(
   check_string(create_disposition)
   check_string(write_disposition)
 
+  labels <- check_labels(getOption("bigrquery.labels"))
+
   load <- list(
     sourceUris = as.list(source_uris),
     sourceFormat = unbox(source_format),
@@ -280,7 +292,12 @@ bq_perform_load <- function(
     load$autodetect <- TRUE
   }
 
-  body <- list(configuration = list(load = load))
+  body <- list(
+    configuration = list(
+      load = load,
+      labels = labels
+    )
+  )
 
   url <- bq_path(billing, jobs = "")
   res <- bq_post(
@@ -332,6 +349,8 @@ bq_perform_query <- function(
   check_bool(use_legacy_sql)
   check_string(priority)
 
+  labels <- check_labels(getOption("bigrquery.labels"))
+
   query <- list(
     query = unbox(query),
     useLegacySql = unbox(use_legacy_sql),
@@ -357,7 +376,12 @@ bq_perform_query <- function(
   }
 
   url <- bq_path(billing, jobs = "")
-  body <- list(configuration = list(query = query))
+  body <- list(
+    configuration = list(
+      query = query,
+      labels = labels
+    )
+  )
 
   res <- bq_post(
     url,
@@ -383,9 +407,16 @@ bq_perform_query_dry_run <- function(
     parameters = parameters,
     use_legacy_sql = use_legacy_sql
   )
+  labels <- check_labels(getOption("bigrquery.labels"))
 
   url <- bq_path(billing, jobs = "")
-  body <- list(configuration = list(query = query, dryRun = unbox(TRUE)))
+  body <- list(
+    configuration = list(
+      query = query,
+      labels = labels,
+      dryRun = unbox(TRUE)
+    )
+  )
 
   res <- bq_post(
     url,
@@ -412,8 +443,16 @@ bq_perform_query_schema <- function(
     use_legacy_sql = FALSE
   )
 
+  labels <- check_labels(getOption("bigrquery.labels"))
+
   url <- bq_path(billing, jobs = "")
-  body <- list(configuration = list(query = query, dryRun = unbox(TRUE)))
+  body <- list(
+    configuration = list(
+      query = query,
+      labels = labels,
+      dryRun = unbox(TRUE)
+    )
+  )
 
   res <- bq_post(
     url,
@@ -463,6 +502,7 @@ bq_perform_copy <- function(
 ) {
   billing <- billing %||% dest$project
   url <- bq_path(billing, jobs = "")
+  labels <- check_labels(getOption("bigrquery.labels"))
 
   body <- list(
     configuration = list(
@@ -471,7 +511,8 @@ bq_perform_copy <- function(
         destinationTable = tableReference(dest),
         createDisposition = unbox(create_disposition),
         writeDisposition = unbox(write_disposition)
-      )
+      ),
+      labels = labels
     )
   )
 

--- a/R/bq-perform.R
+++ b/R/bq-perform.R
@@ -56,6 +56,11 @@ NULL
 #'   snake_case names are automatically converted to camelCase.
 #' @param print_header Whether to print out a header row in the results.
 #' @param billing Identifier of project to bill.
+#' @param labels A named list of strings used to attach
+#'   [BigQuery labels](https://cloud.google.com/bigquery/docs/labels-intro)
+#'   to the resulting job, e.g. `list(env = "prod", team = "data")`. This
+#'   is most useful for cost allocation and other FinOps reporting.
+#'   Defaults to the value of `getOption("bigrquery.labels")`.
 bq_perform_extract <- function(
   x,
   destination_uris,
@@ -63,7 +68,8 @@ bq_perform_extract <- function(
   compression = "NONE",
   ...,
   print_header = TRUE,
-  billing = x$project
+  billing = x$project,
+  labels = getOption("bigrquery.labels")
 ) {
   x <- as_bq_table(x)
   destination_uris <- as.character(destination_uris) # for gs_object
@@ -71,8 +77,7 @@ bq_perform_extract <- function(
   check_string(compression)
   check_bool(print_header)
   check_string(billing)
-
-  labels <- check_labels(getOption("bigrquery.labels"))
+  check_labels(labels)
 
   url <- bq_path(billing, jobs = "")
   body <- list(
@@ -130,7 +135,8 @@ bq_perform_upload <- function(
   write_disposition = "WRITE_EMPTY",
   ...,
   billing = x$project,
-  json_digits = NULL
+  json_digits = NULL,
+  labels = getOption("bigrquery.labels")
 ) {
   x <- as_bq_table(x)
   if (!is.data.frame(values)) {
@@ -142,8 +148,7 @@ bq_perform_upload <- function(
   check_string(write_disposition)
   check_string(billing)
   json_digits <- check_digits(json_digits)
-
-  labels <- check_labels(getOption("bigrquery.labels"))
+  check_labels(labels)
 
   load <- list(
     sourceFormat = unbox(source_format),
@@ -168,7 +173,12 @@ bq_perform_upload <- function(
   metadata <- bq_body(metadata, ...)
   metadata <- list(
     "type" = "application/json; charset=UTF-8",
-    "content" = jsonlite::toJSON(metadata, auto_unbox = TRUE, pretty = TRUE, digits = json_digits)
+    "content" = jsonlite::toJSON(
+      metadata,
+      auto_unbox = TRUE,
+      pretty = TRUE,
+      digits = json_digits
+    )
   )
 
   if (source_format == "NEWLINE_DELIMITED_JSON") {
@@ -261,7 +271,8 @@ bq_perform_load <- function(
   nskip = 0,
   create_disposition = "CREATE_IF_NEEDED",
   write_disposition = "WRITE_EMPTY",
-  ...
+  ...,
+  labels = getOption("bigrquery.labels")
 ) {
   x <- as_bq_table(x)
   source_uris <- as.character(source_uris)
@@ -270,8 +281,7 @@ bq_perform_load <- function(
   check_number_decimal(nskip, min = 0)
   check_string(create_disposition)
   check_string(write_disposition)
-
-  labels <- check_labels(getOption("bigrquery.labels"))
+  check_labels(labels)
 
   load <- list(
     sourceUris = as.list(source_uris),
@@ -339,7 +349,8 @@ bq_perform_query <- function(
   create_disposition = "CREATE_IF_NEEDED",
   write_disposition = "WRITE_EMPTY",
   use_legacy_sql = FALSE,
-  priority = "INTERACTIVE"
+  priority = "INTERACTIVE",
+  labels = getOption("bigrquery.labels")
 ) {
   query <- as_query(query)
   check_string(billing)
@@ -348,8 +359,7 @@ bq_perform_query <- function(
   check_string(write_disposition)
   check_bool(use_legacy_sql)
   check_string(priority)
-
-  labels <- check_labels(getOption("bigrquery.labels"))
+  check_labels(labels)
 
   query <- list(
     query = unbox(query),
@@ -399,7 +409,8 @@ bq_perform_query_dry_run <- function(
   ...,
   default_dataset = NULL,
   parameters = NULL,
-  use_legacy_sql = FALSE
+  use_legacy_sql = FALSE,
+  labels = getOption("bigrquery.labels")
 ) {
   query <- bq_perform_query_data(
     query = query,
@@ -407,7 +418,7 @@ bq_perform_query_dry_run <- function(
     parameters = parameters,
     use_legacy_sql = use_legacy_sql
   )
-  labels <- check_labels(getOption("bigrquery.labels"))
+  check_labels(labels)
 
   url <- bq_path(billing, jobs = "")
   body <- list(
@@ -434,7 +445,8 @@ bq_perform_query_schema <- function(
   billing,
   ...,
   default_dataset = NULL,
-  parameters = NULL
+  parameters = NULL,
+  labels = getOption("bigrquery.labels")
 ) {
   query <- bq_perform_query_data(
     query = query,
@@ -442,8 +454,7 @@ bq_perform_query_schema <- function(
     parameters = parameters,
     use_legacy_sql = FALSE
   )
-
-  labels <- check_labels(getOption("bigrquery.labels"))
+  check_labels(labels)
 
   url <- bq_path(billing, jobs = "")
   body <- list(
@@ -498,11 +509,12 @@ bq_perform_copy <- function(
   create_disposition = "CREATE_IF_NEEDED",
   write_disposition = "WRITE_EMPTY",
   ...,
-  billing = NULL
+  billing = NULL,
+  labels = getOption("bigrquery.labels")
 ) {
   billing <- billing %||% dest$project
   url <- bq_path(billing, jobs = "")
-  labels <- check_labels(getOption("bigrquery.labels"))
+  check_labels(labels)
 
   body <- list(
     configuration = list(

--- a/R/dbi-connection.R
+++ b/R/dbi-connection.R
@@ -8,7 +8,8 @@ BigQueryConnection <- function(
   page_size = 1e4,
   quiet = NA,
   use_legacy_sql = FALSE,
-  bigint = c("integer", "integer64", "numeric", "character")
+  bigint = c("integer", "integer64", "numeric", "character"),
+  labels = NULL
 ) {
   connection_capture()
 
@@ -20,7 +21,8 @@ BigQueryConnection <- function(
     page_size = as.integer(page_size),
     quiet = quiet,
     use_legacy_sql = use_legacy_sql,
-    bigint = match.arg(bigint)
+    bigint = match.arg(bigint),
+    labels = labels
   )
 }
 
@@ -36,7 +38,8 @@ setClass(
     use_legacy_sql = "logical",
     page_size = "integer",
     quiet = "logical",
-    bigint = "character"
+    bigint = "character",
+    labels = "ANY"
   )
 )
 
@@ -113,6 +116,7 @@ setMethod(
       default_dataset = ds,
       quiet = conn@quiet,
       parameters = params,
+      labels = conn@labels,
       ...
     )
     bq_job_wait(job, quiet = conn@quiet)
@@ -256,6 +260,7 @@ dbWriteTable_bq <- function(
     create_disposition = create_disposition,
     write_disposition = write_disposition,
     billing = conn@billing,
+    labels = conn@labels,
     ...
   )
   invisible(TRUE)
@@ -307,6 +312,7 @@ dbAppendTable_bq <- function(conn, name, value, ..., row.names = NULL) {
     create_disposition = "CREATE_NEVER",
     write_disposition = "WRITE_APPEND",
     billing = conn@billing,
+    labels = conn@labels,
     ...
   )
   on_connection_updated(conn, toString(tb))

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -84,6 +84,7 @@ setMethod(
     quiet = NA,
     use_legacy_sql = FALSE,
     bigint = c("integer", "integer64", "numeric", "character"),
+    labels = getOption("bigrquery.labels"),
     ...
   ) {
     check_string(project)
@@ -93,6 +94,7 @@ setMethod(
     check_bool(quiet, allow_na = TRUE)
     check_bool(use_legacy_sql)
     bigint <- arg_match(bigint)
+    check_labels(labels, call = quote(dbConnect()))
 
     BigQueryConnection(
       project = project,
@@ -101,7 +103,8 @@ setMethod(
       page_size = page_size,
       quiet = quiet,
       use_legacy_sql = use_legacy_sql,
-      bigint = bigint
+      bigint = bigint,
+      labels = labels
     )
   }
 )

--- a/R/dbi-result.R
+++ b/R/dbi-result.R
@@ -9,6 +9,7 @@ BigQueryResult <- function(conn, sql, params = NULL, ...) {
     default_dataset = ds,
     quiet = conn@quiet,
     parameters = params,
+    labels = conn@labels,
     ...
   )
 

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -50,7 +50,8 @@ tbl.BigQueryConnection <- function(src, from, ...) {
   schema <- bq_perform_query_schema(
     sql,
     billing = src$con@billing,
-    default_dataset = dataset
+    default_dataset = dataset,
+    labels = src$con@labels
   )
   vars <- map_chr(schema, "[[", "name")
 
@@ -94,7 +95,8 @@ db_compute.BigQueryConnection <- function(
     tb <- bq_project_query(
       con@project,
       sql,
-      destination_table = destination_table
+      destination_table = destination_table,
+      labels = con@labels
     )
   } else {
     ds <- bq_dataset(con@project, con@dataset)
@@ -103,7 +105,8 @@ db_compute.BigQueryConnection <- function(
     tb <- bq_dataset_query(
       ds,
       query = sql,
-      destination_table = destination_table
+      destination_table = destination_table,
+      labels = con@labels
     )
   }
 
@@ -133,7 +136,13 @@ db_copy_to.BigQueryConnection <- function(
 
   tb <- as_bq_table(con, table)
   write <- if (overwrite) "WRITE_TRUNCATE" else "WRITE_EMPTY"
-  bq_table_upload(tb, values, fields = types, write_disposition = write)
+  bq_table_upload(
+    tb,
+    values,
+    fields = types,
+    write_disposition = write,
+    labels = con@labels
+  )
 
   table
 }
@@ -181,10 +190,23 @@ collect.tbl_BigQueryConnection <- function(
     sql <- dbplyr::db_sql_render(con, x)
 
     if (is.null(con@dataset)) {
-      tb <- bq_project_query(billing, sql, quiet = con@quiet, ...)
+      tb <- bq_project_query(
+        billing,
+        sql,
+        quiet = con@quiet,
+        labels = con@labels,
+        ...
+      )
     } else {
       ds <- as_bq_dataset(con)
-      tb <- bq_dataset_query(ds, sql, quiet = con@quiet, billing = billing, ...)
+      tb <- bq_dataset_query(
+        ds,
+        sql,
+        quiet = con@quiet,
+        billing = billing,
+        labels = con@labels,
+        ...
+      )
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -85,3 +85,36 @@ as_query <- function(x, error_arg = caller_arg(x), error_call = caller_env()) {
 has_bigrquerystorage <- function() {
   is_installed("bigrquerystorage")
 }
+
+check_labels <- function(labels) {
+  # Handle NULL, NA, or empty inputs
+  if (is.null(labels) || length(labels) == 0 || (length(labels) == 1 && is.na(labels))) {
+    return(NULL)
+  }
+
+  if (!is.list(labels)) {
+    warning(paste0("Labels must to be a dictionary list; dropping labels"), immediate. = TRUE)
+    return(NULL)
+  }
+  nms <- names(labels)
+  if (is.null(nms) || anyNA(nms) || any(nms == "")) {
+    warning("Label keys must be non-empty strings; dropping labels", immediate. = TRUE, call. = FALSE)
+    return(NULL)
+  }
+  for (nm in names(labels)) {
+    if (!is.character(labels[[nm]]) || length(labels[[nm]]) != 1) {
+      warning(sprintf("Label '%s' must be a single string; dropping labels", nm), immediate. = TRUE)
+      return(NULL)
+    }
+    if (nm != tolower(nm)) {
+      warning(sprintf("Label key '%s' must match ^[a-z0-9_-]{0,62}$; dropping labels", nm), immediate. = TRUE)
+      return(NULL)
+    }
+    if (labels[[nm]] != tolower(labels[[nm]])) {
+      warning(sprintf("Label value '%s' must be empty or match ^[a-z0-9_-]{0,62}$; dropping labels", labels[[nm]]), immediate. = TRUE)
+      return(NULL)
+    }
+  }
+
+  return(labels)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -87,33 +87,26 @@ has_bigrquerystorage <- function() {
 }
 
 check_labels <- function(labels) {
-  # Handle NULL, NA, or empty inputs
   if (is.null(labels) || length(labels) == 0 || (length(labels) == 1 && is.na(labels))) {
     return(NULL)
   }
 
-  if (!is.list(labels)) {
-    warning(paste0("Labels must to be a dictionary list; dropping labels"), immediate. = TRUE)
+  if (!is.character(labels) || is.null(names(labels)) || anyNA(names(labels)) || any(names(labels) == "")) {
+    warning("Labels must be a named character vector; dropping labels", immediate. = TRUE, call. = FALSE)
     return(NULL)
   }
+
   nms <- names(labels)
-  if (is.null(nms) || anyNA(nms) || any(nms == "")) {
-    warning("Label keys must be non-empty strings; dropping labels", immediate. = TRUE, call. = FALSE)
+  bad_keys <- nms[nms != tolower(nms)]
+  if (length(bad_keys) > 0) {
+    warning(sprintf("Label key '%s' must match ^[a-z0-9_-]{0,62}$; dropping labels", bad_keys[[1]]), immediate. = TRUE, call. = FALSE)
     return(NULL)
   }
-  for (nm in names(labels)) {
-    if (!is.character(labels[[nm]]) || length(labels[[nm]]) != 1) {
-      warning(sprintf("Label '%s' must be a single string; dropping labels", nm), immediate. = TRUE)
-      return(NULL)
-    }
-    if (nm != tolower(nm)) {
-      warning(sprintf("Label key '%s' must match ^[a-z0-9_-]{0,62}$; dropping labels", nm), immediate. = TRUE)
-      return(NULL)
-    }
-    if (labels[[nm]] != tolower(labels[[nm]])) {
-      warning(sprintf("Label value '%s' must be empty or match ^[a-z0-9_-]{0,62}$; dropping labels", labels[[nm]]), immediate. = TRUE)
-      return(NULL)
-    }
+
+  bad_vals <- labels[labels != tolower(labels)]
+  if (length(bad_vals) > 0) {
+    warning(sprintf("Label value '%s' must be empty or match ^[a-z0-9_-]{0,62}$; dropping labels", bad_vals[[1]]), immediate. = TRUE, call. = FALSE)
+    return(NULL)
   }
 
   return(labels)

--- a/R/utils.R
+++ b/R/utils.R
@@ -87,27 +87,13 @@ has_bigrquerystorage <- function() {
 }
 
 check_labels <- function(labels) {
-  if (is.null(labels) || length(labels) == 0 || (length(labels) == 1 && is.na(labels))) {
+  if (is.null(labels) || length(labels) == 0) {
     return(NULL)
   }
 
-  if (!is.character(labels) || is.null(names(labels)) || anyNA(names(labels)) || any(names(labels) == "")) {
-    warning("Labels must be a named character vector; dropping labels", immediate. = TRUE, call. = FALSE)
-    return(NULL)
+  if (!is.list(labels) || any(names2(labels) == "")) {
+    cli::cli_abort("Labels must be a named list.")
   }
 
-  nms <- names(labels)
-  bad_keys <- nms[nms != tolower(nms)]
-  if (length(bad_keys) > 0) {
-    warning(sprintf("Label key '%s' must match ^[a-z0-9_-]{0,62}$; dropping labels", bad_keys[[1]]), immediate. = TRUE, call. = FALSE)
-    return(NULL)
-  }
-
-  bad_vals <- labels[labels != tolower(labels)]
-  if (length(bad_vals) > 0) {
-    warning(sprintf("Label value '%s' must be empty or match ^[a-z0-9_-]{0,62}$; dropping labels", bad_vals[[1]]), immediate. = TRUE, call. = FALSE)
-    return(NULL)
-  }
-
-  return(labels)
+  labels
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,59 +93,26 @@ cli_escape <- function(x) {
 }
 
 check_labels <- function(labels) {
-  # Handle NULL, NA, or empty inputs
-  if (
-    is.null(labels) ||
-      length(labels) == 0 ||
-      (length(labels) == 1 && is.na(labels))
-  ) {
+  if (is.null(labels) || length(labels) == 0 || (length(labels) == 1 && is.na(labels))) {
     return(NULL)
   }
 
-  if (!is.list(labels)) {
-    warning(
-      paste0("Labels must to be a dictionary list; dropping labels"),
-      immediate. = TRUE
-    )
+  if (!is.character(labels) || is.null(names(labels)) || anyNA(names(labels)) || any(names(labels) == "")) {
+    warning("Labels must be a named character vector; dropping labels", immediate. = TRUE, call. = FALSE)
     return(NULL)
   }
+
   nms <- names(labels)
-  if (is.null(nms) || anyNA(nms) || any(nms == "")) {
-    warning(
-      "Label keys must be non-empty strings; dropping labels",
-      immediate. = TRUE,
-      call. = FALSE
-    )
+  bad_keys <- nms[nms != tolower(nms)]
+  if (length(bad_keys) > 0) {
+    warning(sprintf("Label key '%s' must match ^[a-z0-9_-]{0,62}$; dropping labels", bad_keys[[1]]), immediate. = TRUE, call. = FALSE)
     return(NULL)
   }
-  for (nm in names(labels)) {
-    if (!is.character(labels[[nm]]) || length(labels[[nm]]) != 1) {
-      warning(
-        sprintf("Label '%s' must be a single string; dropping labels", nm),
-        immediate. = TRUE
-      )
-      return(NULL)
-    }
-    if (nm != tolower(nm)) {
-      warning(
-        sprintf(
-          "Label key '%s' must match ^[a-z0-9_-]{0,62}$; dropping labels",
-          nm
-        ),
-        immediate. = TRUE
-      )
-      return(NULL)
-    }
-    if (labels[[nm]] != tolower(labels[[nm]])) {
-      warning(
-        sprintf(
-          "Label value '%s' must be empty or match ^[a-z0-9_-]{0,62}$; dropping labels",
-          labels[[nm]]
-        ),
-        immediate. = TRUE
-      )
-      return(NULL)
-    }
+
+  bad_vals <- labels[labels != tolower(labels)]
+  if (length(bad_vals) > 0) {
+    warning(sprintf("Label value '%s' must be empty or match ^[a-z0-9_-]{0,62}$; dropping labels", bad_vals[[1]]), immediate. = TRUE, call. = FALSE)
+    return(NULL)
   }
 
   return(labels)

--- a/R/utils.R
+++ b/R/utils.R
@@ -122,3 +122,9 @@ check_labels <- function(
 
   invisible()
 }
+
+cli_escape <- function(x) {
+  x <- gsub("{", "{{", x, fixed = TRUE)
+  x <- gsub("}", "}}", x, fixed = TRUE)
+  x
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,27 +93,13 @@ cli_escape <- function(x) {
 }
 
 check_labels <- function(labels) {
-  if (is.null(labels) || length(labels) == 0 || (length(labels) == 1 && is.na(labels))) {
+  if (is.null(labels) || length(labels) == 0) {
     return(NULL)
   }
 
-  if (!is.character(labels) || is.null(names(labels)) || anyNA(names(labels)) || any(names(labels) == "")) {
-    warning("Labels must be a named character vector; dropping labels", immediate. = TRUE, call. = FALSE)
-    return(NULL)
+  if (!is.list(labels) || any(names2(labels) == "")) {
+    cli::cli_abort("Labels must be a named list.")
   }
 
-  nms <- names(labels)
-  bad_keys <- nms[nms != tolower(nms)]
-  if (length(bad_keys) > 0) {
-    warning(sprintf("Label key '%s' must match ^[a-z0-9_-]{0,62}$; dropping labels", bad_keys[[1]]), immediate. = TRUE, call. = FALSE)
-    return(NULL)
-  }
-
-  bad_vals <- labels[labels != tolower(labels)]
-  if (length(bad_vals) > 0) {
-    warning(sprintf("Label value '%s' must be empty or match ^[a-z0-9_-]{0,62}$; dropping labels", bad_vals[[1]]), immediate. = TRUE, call. = FALSE)
-    return(NULL)
-  }
-
-  return(labels)
+  labels
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,14 +92,33 @@ cli_escape <- function(x) {
   x
 }
 
-check_labels <- function(labels) {
-  if (is.null(labels) || length(labels) == 0) {
-    return(NULL)
+check_labels <- function(
+  labels,
+  arg = caller_arg(labels),
+  call = caller_env()
+) {
+  if (is.null(labels)) {
+    return(invisible())
   }
 
   if (!is.list(labels) || any(names2(labels) == "")) {
-    cli::cli_abort("Labels must be a named list.")
+    stop_input_type(
+      labels,
+      "a named list",
+      allow_null = TRUE,
+      arg = arg,
+      call = call
+    )
+  }
+  is_string <- vapply(labels, is_string, logical(1))
+  if (!all(is_string)) {
+    stop_input_type(
+      labels,
+      "a named list of strings",
+      arg = arg,
+      call = call
+    )
   }
 
-  labels
+  invisible()
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -91,3 +91,62 @@ cli_escape <- function(x) {
   x <- gsub("}", "}}", x, fixed = TRUE)
   x
 }
+
+check_labels <- function(labels) {
+  # Handle NULL, NA, or empty inputs
+  if (
+    is.null(labels) ||
+      length(labels) == 0 ||
+      (length(labels) == 1 && is.na(labels))
+  ) {
+    return(NULL)
+  }
+
+  if (!is.list(labels)) {
+    warning(
+      paste0("Labels must to be a dictionary list; dropping labels"),
+      immediate. = TRUE
+    )
+    return(NULL)
+  }
+  nms <- names(labels)
+  if (is.null(nms) || anyNA(nms) || any(nms == "")) {
+    warning(
+      "Label keys must be non-empty strings; dropping labels",
+      immediate. = TRUE,
+      call. = FALSE
+    )
+    return(NULL)
+  }
+  for (nm in names(labels)) {
+    if (!is.character(labels[[nm]]) || length(labels[[nm]]) != 1) {
+      warning(
+        sprintf("Label '%s' must be a single string; dropping labels", nm),
+        immediate. = TRUE
+      )
+      return(NULL)
+    }
+    if (nm != tolower(nm)) {
+      warning(
+        sprintf(
+          "Label key '%s' must match ^[a-z0-9_-]{0,62}$; dropping labels",
+          nm
+        ),
+        immediate. = TRUE
+      )
+      return(NULL)
+    }
+    if (labels[[nm]] != tolower(labels[[nm]])) {
+      warning(
+        sprintf(
+          "Label value '%s' must be empty or match ^[a-z0-9_-]{0,62}$; dropping labels",
+          labels[[nm]]
+        ),
+        immediate. = TRUE
+      )
+      return(NULL)
+    }
+  }
+
+  return(labels)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,7 +23,8 @@
   op <- options()
   defaults <- list(
     bigrquery.quiet = NA,
-    bigrquery.page.size = 1e4
+    bigrquery.page.size = 1e4,
+    bigrquery.labels = NULL
   )
   toset <- !(names(defaults) %in% names(op))
   if (any(toset)) {

--- a/man/api-perform.Rd
+++ b/man/api-perform.Rd
@@ -18,7 +18,8 @@ bq_perform_extract(
   compression = "NONE",
   ...,
   print_header = TRUE,
-  billing = x$project
+  billing = x$project,
+  labels = getOption("bigrquery.labels")
 )
 
 bq_perform_upload(
@@ -30,7 +31,8 @@ bq_perform_upload(
   write_disposition = "WRITE_EMPTY",
   ...,
   billing = x$project,
-  json_digits = NULL
+  json_digits = NULL,
+  labels = getOption("bigrquery.labels")
 )
 
 bq_perform_load(
@@ -42,7 +44,8 @@ bq_perform_load(
   nskip = 0,
   create_disposition = "CREATE_IF_NEEDED",
   write_disposition = "WRITE_EMPTY",
-  ...
+  ...,
+  labels = getOption("bigrquery.labels")
 )
 
 bq_perform_query(
@@ -55,7 +58,8 @@ bq_perform_query(
   create_disposition = "CREATE_IF_NEEDED",
   write_disposition = "WRITE_EMPTY",
   use_legacy_sql = FALSE,
-  priority = "INTERACTIVE"
+  priority = "INTERACTIVE",
+  labels = getOption("bigrquery.labels")
 )
 
 bq_perform_query_dry_run(
@@ -64,7 +68,8 @@ bq_perform_query_dry_run(
   ...,
   default_dataset = NULL,
   parameters = NULL,
-  use_legacy_sql = FALSE
+  use_legacy_sql = FALSE,
+  labels = getOption("bigrquery.labels")
 )
 
 bq_perform_query_schema(
@@ -72,7 +77,8 @@ bq_perform_query_schema(
   billing,
   ...,
   default_dataset = NULL,
-  parameters = NULL
+  parameters = NULL,
+  labels = getOption("bigrquery.labels")
 )
 
 bq_perform_copy(
@@ -81,7 +87,8 @@ bq_perform_copy(
   create_disposition = "CREATE_IF_NEEDED",
   write_disposition = "WRITE_EMPTY",
   ...,
-  billing = NULL
+  billing = NULL,
+  labels = getOption("bigrquery.labels")
 )
 }
 \arguments{
@@ -115,6 +122,12 @@ snake_case names are automatically converted to camelCase.}
 \item{print_header}{Whether to print out a header row in the results.}
 
 \item{billing}{Identifier of project to bill.}
+
+\item{labels}{A named list of strings used to attach
+\href{https://cloud.google.com/bigquery/docs/labels-intro}{BigQuery labels}
+to the resulting job, e.g. \code{list(env = "prod", team = "data")}. This
+is most useful for cost allocation and other FinOps reporting.
+Defaults to the value of \code{getOption("bigrquery.labels")}.}
 
 \item{values}{Data frame of values to insert.}
 

--- a/man/bigquery.Rd
+++ b/man/bigquery.Rd
@@ -15,6 +15,7 @@
   quiet = NA,
   use_legacy_sql = FALSE,
   bigint = c("integer", "integer64", "numeric", "character"),
+  labels = getOption("bigrquery.labels"),
   ...
 )
 }
@@ -34,8 +35,14 @@ if \code{NA} picks based on whether or not you're in an interactive context.}
 
 \item{bigint}{The R type that BigQuery's 64-bit integer types should be mapped to.
 The default is \code{"integer"} which returns R's \code{integer} type but results in \code{NA} for
-values above/below +/- 2147483647. \code{"integer64"} returns a \link[bit64:bit64-package]{bit64::integer64},
+values above/below +/- 2147483647. \code{"integer64"} returns a \link[bit64:integer64]{bit64::integer64},
 which allows the full range of 64 bit integers.}
+
+\item{labels}{A named list of strings used to attach
+\href{https://cloud.google.com/bigquery/docs/labels-intro}{BigQuery labels}
+to the resulting job, e.g. \code{list(env = "prod", team = "data")}. This
+is most useful for cost allocation and other FinOps reporting.
+Defaults to the value of \code{getOption("bigrquery.labels")}.}
 
 \item{...}{Other arguments for compatibility with generic; currently ignored.}
 }

--- a/man/bigrquery-package.Rd
+++ b/man/bigrquery-package.Rd
@@ -35,6 +35,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Hadley Wickham \email{hadley@posit.co} (\href{https://orcid.org/0000-0003-4757-117X}{ORCID})
   \item Jennifer Bryan \email{jenny@posit.co} (\href{https://orcid.org/0000-0002-6983-2759}{ORCID})
 }
 

--- a/man/bq_auth.Rd
+++ b/man/bq_auth.Rd
@@ -143,8 +143,8 @@ bq_auth(path = "foofy-83ee9e7c9c48.json")
 
 }
 \seealso{
-Other auth functions: 
-\code{\link{bq_auth_configure}()},
-\code{\link{bq_deauth}()}
+Other auth functions:
+\code{\link[=bq_auth_configure]{bq_auth_configure()}},
+\code{\link[=bq_deauth]{bq_deauth()}}
 }
 \concept{auth functions}

--- a/man/bq_auth_configure.Rd
+++ b/man/bq_auth_configure.Rd
@@ -21,7 +21,7 @@ secret, in one of the forms supported for the \code{txt} argument of
 \value{
 \itemize{
 \item \code{bq_auth_configure()}: An object of R6 class
-\link[gargle:AuthState-class]{gargle::AuthState}, invisibly.
+\link[gargle:AuthState]{gargle::AuthState}, invisibly.
 \item \code{bq_oauth_client()}: the current user-configured OAuth client.
 }
 }
@@ -60,8 +60,8 @@ bq_oauth_client()
 bq_auth_configure(client = original_client)
 }
 \seealso{
-Other auth functions: 
-\code{\link{bq_auth}()},
-\code{\link{bq_deauth}()}
+Other auth functions:
+\code{\link[=bq_auth]{bq_auth()}},
+\code{\link[=bq_deauth]{bq_deauth()}}
 }
 \concept{auth functions}

--- a/man/bq_deauth.Rd
+++ b/man/bq_deauth.Rd
@@ -20,8 +20,8 @@ bq_deauth()
 }
 }
 \seealso{
-Other auth functions: 
-\code{\link{bq_auth}()},
-\code{\link{bq_auth_configure}()}
+Other auth functions:
+\code{\link[=bq_auth]{bq_auth()}},
+\code{\link[=bq_auth_configure]{bq_auth_configure()}}
 }
 \concept{auth functions}

--- a/man/bq_has_token.Rd
+++ b/man/bq_has_token.Rd
@@ -17,7 +17,7 @@ requests.
 bq_has_token()
 }
 \seealso{
-Other low-level API functions: 
-\code{\link{bq_token}()}
+Other low-level API functions:
+\code{\link[=bq_token]{bq_token()}}
 }
 \concept{low-level API functions}

--- a/man/bq_table_download.Rd
+++ b/man/bq_table_download.Rd
@@ -42,7 +42,7 @@ if \code{NA} picks based on whether or not you're in an interactive context.}
 \item{bigint}{The R type that BigQuery's 64-bit integer types should be
 mapped to. The default is \code{"integer"}, which returns R's \code{integer} type,
 but results in \code{NA} for values above/below +/- 2147483647. \code{"integer64"}
-returns a \link[bit64:bit64-package]{bit64::integer64}, which allows the full range of 64 bit
+returns a \link[bit64:integer64]{bit64::integer64}, which allows the full range of 64 bit
 integers.}
 
 \item{api}{Which API to use? The \code{"json"} API works where ever bigrquery

--- a/man/bq_token.Rd
+++ b/man/bq_token.Rd
@@ -7,7 +7,7 @@
 bq_token()
 }
 \value{
-A \code{request} object (an S3 class provided by \link[httr:httr-package]{httr}).
+A \code{request} object (an S3 class provided by \link[httr:httr]{httr}).
 }
 \description{
 For internal use or for those programming around the BigQuery API.
@@ -25,7 +25,7 @@ bq_token()
 }
 }
 \seealso{
-Other low-level API functions: 
-\code{\link{bq_has_token}()}
+Other low-level API functions:
+\code{\link[=bq_has_token]{bq_has_token()}}
 }
 \concept{low-level API functions}

--- a/man/bq_user.Rd
+++ b/man/bq_user.Rd
@@ -19,6 +19,6 @@ bq_user()
 }
 }
 \seealso{
-\code{\link[gargle:token-info]{gargle::token_userinfo()}}, \code{\link[gargle:token-info]{gargle::token_email()}},
-\code{\link[gargle:token-info]{gargle::token_tokeninfo()}}
+\code{\link[gargle:token_userinfo]{gargle::token_userinfo()}}, \code{\link[gargle:token_email]{gargle::token_email()}},
+\code{\link[gargle:token_tokeninfo]{gargle::token_tokeninfo()}}
 }

--- a/man/collect.tbl_BigQueryConnection.Rd
+++ b/man/collect.tbl_BigQueryConnection.Rd
@@ -4,7 +4,7 @@
 \alias{collect.tbl_BigQueryConnection}
 \title{Collect a BigQuery table}
 \usage{
-collect.tbl_BigQueryConnection(
+\method{collect}{tbl_BigQueryConnection}(
   x,
   ...,
   n = Inf,
@@ -49,6 +49,6 @@ This collect method is specialised for BigQuery tables, generating the
 SQL from your dplyr commands, then calling \code{\link[=bq_project_query]{bq_project_query()}}
 or \code{\link[=bq_dataset_query]{bq_dataset_query()}} to run the query, then \code{\link[=bq_table_download]{bq_table_download()}}
 to download the results. Thus the arguments are a combination of the
-arguments to \code{\link[dplyr:compute]{dplyr::collect()}}, \code{bq_project_query()}/\code{bq_dataset_query()},
+arguments to \code{\link[dplyr:collect]{dplyr::collect()}}, \code{bq_project_query()}/\code{bq_dataset_query()},
 and \code{bq_table_download()}.
 }

--- a/tests/testthat/_snaps/dbi-driver.md
+++ b/tests/testthat/_snaps/dbi-driver.md
@@ -1,0 +1,8 @@
+# dbConnect() validates labels
+
+    Code
+      dbConnect(bigquery(), project = bq_test_project(), labels = "oops")
+    Condition
+      Error in `dbConnect()`:
+      ! `labels` must be a named list or `NULL`, not the string "oops".
+

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -6,3 +6,21 @@
       Error in `bq_check_namespace()`:
       ! The package "invalid package name" is required to parse BigQuery 'FIELD_TYPE' fields.
 
+# check_labels() errors on invalid inputs
+
+    Code
+      check_labels(c(env = "prod"))
+    Condition
+      Error:
+      ! `c(env = "prod")` must be a named list or `NULL`, not the string "prod".
+    Code
+      check_labels(list("no-name"))
+    Condition
+      Error:
+      ! `list("no-name")` must be a named list or `NULL`, not a list.
+    Code
+      check_labels(list(env = 1))
+    Condition
+      Error:
+      ! `list(env = 1)` must be a named list of strings, not a list.
+

--- a/tests/testthat/test-dbi-driver.R
+++ b/tests/testthat/test-dbi-driver.R
@@ -10,3 +10,25 @@ test_that("connecting yields a BigQueryConnection", {
   con <- dbConnect(bigquery(), project = bq_test_project())
   expect_s4_class(con, "BigQueryConnection")
 })
+
+test_that("dbConnect() captures labels", {
+  con <- dbConnect(
+    bigquery(),
+    project = bq_test_project(),
+    labels = list(env = "test")
+  )
+  expect_equal(con@labels, list(env = "test"))
+})
+
+test_that("dbConnect() validates labels", {
+  expect_snapshot(
+    error = TRUE,
+    dbConnect(bigquery(), project = bq_test_project(), labels = "oops")
+  )
+})
+
+test_that("dbConnect() reads bigrquery.labels option", {
+  withr::local_options(bigrquery.labels = list(env = "from-option"))
+  con <- dbConnect(bigquery(), project = bq_test_project())
+  expect_equal(con@labels, list(env = "from-option"))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -5,3 +5,19 @@ test_that("bq_check_namespace() works", {
     error = TRUE
   )
 })
+
+test_that("check_labels() accepts valid labels and NULL-like inputs", {
+  expect_null(check_labels(NULL))
+  expect_null(check_labels(NA))
+  expect_null(check_labels(list()))
+
+  expect_equal(check_labels(list(env = "prod")), list(env = "prod"))
+  expect_equal(check_labels(list(env = "prod", team = "data")), list(env = "prod", team = "data"))
+})
+
+test_that("check_labels() warns and returns NULL for invalid inputs", {
+  expect_warning(check_labels("not-a-list"), "dictionary list")
+  expect_warning(check_labels(list("no-name")), "non-empty strings")
+  expect_warning(check_labels(list(ENV = "prod")), "must match")
+  expect_warning(check_labels(list(env = "Prod")), "must be empty or match")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -9,15 +9,15 @@ test_that("bq_check_namespace() works", {
 test_that("check_labels() accepts valid labels and NULL-like inputs", {
   expect_null(check_labels(NULL))
   expect_null(check_labels(NA))
-  expect_null(check_labels(list()))
+  expect_null(check_labels(character()))
 
-  expect_equal(check_labels(list(env = "prod")), list(env = "prod"))
-  expect_equal(check_labels(list(env = "prod", team = "data")), list(env = "prod", team = "data"))
+  expect_equal(check_labels(c(env = "prod")), c(env = "prod"))
+  expect_equal(check_labels(c(env = "prod", team = "data")), c(env = "prod", team = "data"))
 })
 
 test_that("check_labels() warns and returns NULL for invalid inputs", {
-  expect_warning(check_labels("not-a-list"), "dictionary list")
-  expect_warning(check_labels(list("no-name")), "non-empty strings")
-  expect_warning(check_labels(list(ENV = "prod")), "must match")
-  expect_warning(check_labels(list(env = "Prod")), "must be empty or match")
+  expect_warning(check_labels(list(env = "prod")), "named character vector")
+  expect_warning(check_labels(c("no-name")), "named character vector")
+  expect_warning(check_labels(c(ENV = "prod")), "must match")
+  expect_warning(check_labels(c(env = "Prod")), "must be empty or match")
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -8,16 +8,14 @@ test_that("bq_check_namespace() works", {
 
 test_that("check_labels() accepts valid labels and NULL-like inputs", {
   expect_null(check_labels(NULL))
-  expect_null(check_labels(NA))
-  expect_null(check_labels(character()))
+  expect_null(check_labels(list()))
 
-  expect_equal(check_labels(c(env = "prod")), c(env = "prod"))
-  expect_equal(check_labels(c(env = "prod", team = "data")), c(env = "prod", team = "data"))
+  expect_equal(check_labels(list(env = "prod")), list(env = "prod"))
+  expect_equal(check_labels(list(env = "prod", team = "data")), list(env = "prod", team = "data"))
+  expect_equal(check_labels(list(env = "")), list(env = ""))
 })
 
-test_that("check_labels() warns and returns NULL for invalid inputs", {
-  expect_warning(check_labels(list(env = "prod")), "named character vector")
-  expect_warning(check_labels(c("no-name")), "named character vector")
-  expect_warning(check_labels(c(ENV = "prod")), "must match")
-  expect_warning(check_labels(c(env = "Prod")), "must be empty or match")
+test_that("check_labels() errors on invalid inputs", {
+  expect_error(check_labels(c(env = "prod")), "named list")
+  expect_error(check_labels(list("no-name")), "named list")
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -13,16 +13,14 @@ test_that("cli_escape() doubles cli braces", {
 
 test_that("check_labels() accepts valid labels and NULL-like inputs", {
   expect_null(check_labels(NULL))
-  expect_null(check_labels(NA))
-  expect_null(check_labels(character()))
+  expect_null(check_labels(list()))
 
-  expect_equal(check_labels(c(env = "prod")), c(env = "prod"))
-  expect_equal(check_labels(c(env = "prod", team = "data")), c(env = "prod", team = "data"))
+  expect_equal(check_labels(list(env = "prod")), list(env = "prod"))
+  expect_equal(check_labels(list(env = "prod", team = "data")), list(env = "prod", team = "data"))
+  expect_equal(check_labels(list(env = "")), list(env = ""))
 })
 
-test_that("check_labels() warns and returns NULL for invalid inputs", {
-  expect_warning(check_labels(list(env = "prod")), "named character vector")
-  expect_warning(check_labels(c("no-name")), "named character vector")
-  expect_warning(check_labels(c(ENV = "prod")), "must match")
-  expect_warning(check_labels(c(env = "Prod")), "must be empty or match")
+test_that("check_labels() errors on invalid inputs", {
+  expect_error(check_labels(c(env = "prod")), "named list")
+  expect_error(check_labels(list("no-name")), "named list")
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -26,3 +26,8 @@ test_that("check_labels() errors on invalid inputs", {
     check_labels(list(env = 1))
   })
 })
+
+test_that("cli_escape() doubles cli braces", {
+  expect_equal(cli_escape("no braces"), "no braces")
+  expect_equal(cli_escape("{x}"), "{{x}}")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -10,3 +10,22 @@ test_that("cli_escape() doubles cli braces", {
   expect_equal(cli_escape("no braces"), "no braces")
   expect_equal(cli_escape("{x}"), "{{x}}")
 })
+
+test_that("check_labels() accepts valid labels and NULL-like inputs", {
+  expect_null(check_labels(NULL))
+  expect_null(check_labels(NA))
+  expect_null(check_labels(list()))
+
+  expect_equal(check_labels(list(env = "prod")), list(env = "prod"))
+  expect_equal(
+    check_labels(list(env = "prod", team = "data")),
+    list(env = "prod", team = "data")
+  )
+})
+
+test_that("check_labels() warns and returns NULL for invalid inputs", {
+  expect_warning(check_labels("not-a-list"), "dictionary list")
+  expect_warning(check_labels(list("no-name")), "non-empty strings")
+  expect_warning(check_labels(list(ENV = "prod")), "must match")
+  expect_warning(check_labels(list(env = "Prod")), "must be empty or match")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -12,15 +12,17 @@ test_that("cli_escape() doubles cli braces", {
 })
 
 test_that("check_labels() accepts valid labels and NULL-like inputs", {
-  expect_null(check_labels(NULL))
-  expect_null(check_labels(list()))
-
-  expect_equal(check_labels(list(env = "prod")), list(env = "prod"))
-  expect_equal(check_labels(list(env = "prod", team = "data")), list(env = "prod", team = "data"))
-  expect_equal(check_labels(list(env = "")), list(env = ""))
+  expect_no_error(check_labels(NULL))
+  expect_no_error(check_labels(list()))
+  expect_no_error(check_labels(list(env = "prod")))
+  expect_no_error(check_labels(list(env = "prod", team = "data")))
+  expect_no_error(check_labels(list(env = "")))
 })
 
 test_that("check_labels() errors on invalid inputs", {
-  expect_error(check_labels(c(env = "prod")), "named list")
-  expect_error(check_labels(list("no-name")), "named list")
+  expect_snapshot(error = TRUE, {
+    check_labels(c(env = "prod"))
+    check_labels(list("no-name"))
+    check_labels(list(env = 1))
+  })
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -14,18 +14,15 @@ test_that("cli_escape() doubles cli braces", {
 test_that("check_labels() accepts valid labels and NULL-like inputs", {
   expect_null(check_labels(NULL))
   expect_null(check_labels(NA))
-  expect_null(check_labels(list()))
+  expect_null(check_labels(character()))
 
-  expect_equal(check_labels(list(env = "prod")), list(env = "prod"))
-  expect_equal(
-    check_labels(list(env = "prod", team = "data")),
-    list(env = "prod", team = "data")
-  )
+  expect_equal(check_labels(c(env = "prod")), c(env = "prod"))
+  expect_equal(check_labels(c(env = "prod", team = "data")), c(env = "prod", team = "data"))
 })
 
 test_that("check_labels() warns and returns NULL for invalid inputs", {
-  expect_warning(check_labels("not-a-list"), "dictionary list")
-  expect_warning(check_labels(list("no-name")), "non-empty strings")
-  expect_warning(check_labels(list(ENV = "prod")), "must match")
-  expect_warning(check_labels(list(env = "Prod")), "must be empty or match")
+  expect_warning(check_labels(list(env = "prod")), "named character vector")
+  expect_warning(check_labels(c("no-name")), "named character vector")
+  expect_warning(check_labels(c(ENV = "prod")), "must match")
+  expect_warning(check_labels(c(env = "Prod")), "must be empty or match")
 })


### PR DESCRIPTION
Added labels to job creation calls for FinOps purposes
Labels can be set globally via:
options(bigrquery.labels = list(env = "prod", team = "analytics"))
Labels are then automatically attached to all BigQuery job requests (query, load, extract, copy).
- Added check_labels() to validate labels against BigQuery's key/value constraints before sending
- Added bigrquery.labels default option (NULL) in .onLoad()
- Added tests for check_labels()
- Fixed pre-existing inconsistency: auto_unbox = TRUE was already present in bq_post/bq_patch but was missing from the toJSON calls in bq_perform_upload and bq_parse_single

Fixes #652